### PR TITLE
Flash click-to-sustain with channel locking

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -341,12 +341,12 @@
                   <span x-text="expandedFixtureId === fixture.id ? '\u25B2' : '\u25BC'"></span>
                 </button>
                 <button class="btn btn-sm"
-                        @mousedown.prevent="flashHold(fixture.id)"
-                        @mouseup="flashRelease(fixture.id)"
-                        @mouseleave="flashRelease(fixture.id)"
-                        @touchstart.prevent="flashHold(fixture.id)"
-                        @touchend="flashRelease(fixture.id)"
-                        @touchcancel="flashRelease(fixture.id)">Flash</button>
+                        @mousedown.prevent="flashStart(fixture.id)"
+                        @mouseup="flashEnd(fixture.id)"
+                        @mouseleave="flashEnd(fixture.id)"
+                        @touchstart.prevent="flashStart(fixture.id)"
+                        @touchend="flashEnd(fixture.id)"
+                        @touchcancel="flashEnd(fixture.id)">Flash</button>
                 <button class="btn btn-sm btn-reset"
                         x-show="hasResetChannel(fixture)"
                         @click="resetFixture(fixture.id)"

--- a/server/public/js/fixture-manager.js
+++ b/server/public/js/fixture-manager.js
@@ -166,9 +166,11 @@ function dmxrFixtureManager() {
       }
     },
 
-    async flashHold(id) {
+    flashStart(id) {
+      this._flashStartTime = Date.now();
+      this._flashId = id;
       try {
-        await fetch("/fixtures/" + id + "/test", {
+        fetch("/fixtures/" + id + "/test", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ action: "flash-hold" }),
@@ -178,15 +180,30 @@ function dmxrFixtureManager() {
       }
     },
 
-    async flashRelease(id) {
-      try {
-        await fetch("/fixtures/" + id + "/test", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ action: "flash-release" }),
-        });
-      } catch {
-        // ignore
+    flashEnd(id) {
+      var held = Date.now() - (this._flashStartTime || 0);
+      if (held < 200) {
+        // Short click: server handles 2s sustain with channel locking
+        try {
+          fetch("/fixtures/" + id + "/test", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ action: "flash-click" }),
+          });
+        } catch {
+          // ignore
+        }
+      } else {
+        // Long hold: release immediately
+        try {
+          fetch("/fixtures/" + id + "/test", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ action: "flash-release" }),
+          });
+        } catch {
+          // ignore
+        }
       }
     },
 

--- a/server/src/dmx/universe-manager.test.ts
+++ b/server/src/dmx/universe-manager.test.ts
@@ -363,4 +363,100 @@ describe("createUniverseManager", () => {
       expect(mgr.getDmxSendStatus().lastSendError).toBeNull();
     });
   });
+
+  describe("channel locking", () => {
+    it("lockChannels prevents applyFixtureUpdate from writing locked addresses", () => {
+      manager.lockChannels([1, 2]);
+      mock.updateCalls.length = 0;
+
+      const count = manager.applyFixtureUpdate({
+        fixture: "test",
+        channels: { "1": 255, "2": 128, "3": 64 },
+      });
+
+      // Only channel 3 should be written
+      expect(count).toBe(1);
+      expect(mock.updateCalls).toHaveLength(1);
+      expect(mock.updateCalls[0]).toEqual({ 3: 64 });
+    });
+
+    it("unlockChannels allows writes again", () => {
+      manager.lockChannels([1, 2]);
+      manager.unlockChannels([1, 2]);
+      mock.updateCalls.length = 0;
+
+      const count = manager.applyFixtureUpdate({
+        fixture: "test",
+        channels: { "1": 255, "2": 128 },
+      });
+
+      expect(count).toBe(2);
+      expect(mock.updateCalls[0]).toEqual({ 1: 255, 2: 128 });
+    });
+
+    it("blackout skips locked channels", () => {
+      // Set some values first
+      manager.applyFixtureUpdate({
+        fixture: "test",
+        channels: { "1": 255, "2": 128, "3": 64 },
+      });
+
+      // Lock channels 1 and 2
+      manager.lockChannels([1, 2]);
+      mock.updateCalls.length = 0;
+
+      manager.blackout();
+
+      // Should use selective update (not updateAll)
+      expect(mock.updateAllCalls).toHaveLength(0);
+      expect(mock.updateCalls).toHaveLength(1);
+
+      const update = mock.updateCalls[0];
+      // Locked channels preserved at their values
+      expect(update[1]).toBe(255);
+      expect(update[2]).toBe(128);
+      // Non-locked channels zeroed
+      expect(update[3]).toBe(0);
+      expect(update[100]).toBe(0);
+    });
+
+    it("whiteout skips locked channels", () => {
+      manager.applyFixtureUpdate({
+        fixture: "test",
+        channels: { "1": 100, "2": 50 },
+      });
+      manager.lockChannels([1, 2]);
+      mock.updateCalls.length = 0;
+
+      manager.whiteout();
+
+      expect(mock.updateAllCalls).toHaveLength(0);
+      expect(mock.updateCalls).toHaveLength(1);
+
+      const update = mock.updateCalls[0];
+      expect(update[1]).toBe(100);
+      expect(update[2]).toBe(50);
+      expect(update[3]).toBe(255);
+      expect(update[100]).toBe(255);
+    });
+
+    it("hasLockedChannels returns correct state", () => {
+      expect(manager.hasLockedChannels()).toBe(false);
+      manager.lockChannels([1]);
+      expect(manager.hasLockedChannels()).toBe(true);
+      manager.unlockChannels([1]);
+      expect(manager.hasLockedChannels()).toBe(false);
+    });
+
+    it("returns 0 when all channels are locked", () => {
+      manager.lockChannels([1, 2, 3]);
+
+      const count = manager.applyFixtureUpdate({
+        fixture: "test",
+        channels: { "1": 255, "2": 128, "3": 64 },
+      });
+
+      expect(count).toBe(0);
+    });
+  });
 });

--- a/server/src/dmx/universe-manager.ts
+++ b/server/src/dmx/universe-manager.ts
@@ -39,6 +39,12 @@ export interface UniverseManager {
    *  These are restored immediately after blackout/whiteout to prevent
    *  motors from slamming to mechanical limits at DMX 0 or 255. */
   readonly registerSafePositions: (channels: Record<number, number>) => void;
+  /** Lock DMX addresses so applyFixtureUpdate and blackout/whiteout skip them. */
+  readonly lockChannels: (addresses: readonly number[]) => void;
+  /** Unlock DMX addresses so normal writes resume. */
+  readonly unlockChannels: (addresses: readonly number[]) => void;
+  /** Returns true if any channels are currently locked. */
+  readonly hasLockedChannels: () => boolean;
 }
 
 function clampValue(value: number): number {
@@ -75,6 +81,7 @@ export function createUniverseManager(
 ): UniverseManager {
   const activeChannels = new Map<number, number>();
   const safePositions = new Map<number, number>();
+  const lockedChannels = new Set<number>();
   const log = options.logger;
   let lastSendTime: number | null = null;
   let lastSendError: string | null = null;
@@ -109,6 +116,18 @@ export function createUniverseManager(
         return 0;
       }
 
+      // Filter out locked channels (flash takes priority)
+      if (lockedChannels.size > 0) {
+        for (const key of Object.keys(dmxUpdate)) {
+          if (lockedChannels.has(Number(key))) {
+            delete dmxUpdate[Number(key)];
+          }
+        }
+        if (Object.keys(dmxUpdate).length === 0) {
+          return 0;
+        }
+      }
+
       for (const [ch, val] of Object.entries(dmxUpdate)) {
         const chNum = Number(ch);
         if (val > 0) {
@@ -136,14 +155,25 @@ export function createUniverseManager(
     blackout(): void {
       blackoutActive = true;
       const prevCount = activeChannels.size;
+
+      // Preserve locked channel values before clearing
+      const lockedValues = new Map<number, number>();
+      for (const ch of lockedChannels) {
+        lockedValues.set(ch, activeChannels.get(ch) ?? 0);
+      }
+
       activeChannels.clear();
 
-      if (safePositions.size > 0) {
-        // Selective blackout: zero everything EXCEPT motor channels in a
-        // single atomic update so pan/tilt values never change at all.
+      // Always use selective update when we have safe positions or locked channels
+      if (safePositions.size > 0 || lockedChannels.size > 0) {
         const selective: Record<number, number> = {};
         for (let ch = MIN_CHANNEL; ch <= MAX_CHANNEL; ch++) {
-          if (safePositions.has(ch)) {
+          if (lockedChannels.has(ch)) {
+            // Locked channels (flash) keep their current value
+            const val = lockedValues.get(ch) ?? 0;
+            selective[ch] = val;
+            if (val > 0) activeChannels.set(ch, val);
+          } else if (safePositions.has(ch)) {
             selective[ch] = safePositions.get(ch)!;
             activeChannels.set(ch, safePositions.get(ch)!);
           } else {
@@ -151,13 +181,10 @@ export function createUniverseManager(
           }
         }
         safeSend(`blackout-selective ${MAX_CHANNEL}ch`, () => universe.update(selective));
-        const snapshot = [...safePositions.entries()]
-          .sort(([a], [b]) => a - b)
-          .map(([ch, val]) => `${ch}:${val}`)
-          .join(" ");
+        const preserved = safePositions.size + lockedChannels.size;
         pipeLog("info",
-          `BLACKOUT: zeroed ${MAX_CHANNEL - safePositions.size} channels, ` +
-          `preserved ${safePositions.size} motor channels: ${snapshot}`,
+          `BLACKOUT: zeroed ${MAX_CHANNEL - preserved} channels, ` +
+          `preserved ${safePositions.size} motor + ${lockedChannels.size} locked`,
         );
       } else {
         safeSend("blackout", () => universe.updateAll(0));
@@ -168,14 +195,24 @@ export function createUniverseManager(
 
     whiteout(): void {
       blackoutActive = true;
+
+      // Preserve locked channel values before clearing
+      const lockedValues = new Map<number, number>();
+      for (const ch of lockedChannels) {
+        lockedValues.set(ch, activeChannels.get(ch) ?? 0);
+      }
+
       activeChannels.clear();
 
-      if (safePositions.size > 0) {
-        // Selective whiteout: set everything to 255 EXCEPT motor channels
-        // in a single atomic update so pan/tilt values never change at all.
+      // Always use selective update when we have safe positions or locked channels
+      if (safePositions.size > 0 || lockedChannels.size > 0) {
         const selective: Record<number, number> = {};
         for (let ch = MIN_CHANNEL; ch <= MAX_CHANNEL; ch++) {
-          if (safePositions.has(ch)) {
+          if (lockedChannels.has(ch)) {
+            const val = lockedValues.get(ch) ?? 0;
+            selective[ch] = val;
+            if (val > 0) activeChannels.set(ch, val);
+          } else if (safePositions.has(ch)) {
             selective[ch] = safePositions.get(ch)!;
             activeChannels.set(ch, safePositions.get(ch)!);
           } else {
@@ -184,13 +221,10 @@ export function createUniverseManager(
           }
         }
         safeSend(`whiteout-selective ${MAX_CHANNEL}ch`, () => universe.update(selective));
-        const snapshot = [...safePositions.entries()]
-          .sort(([a], [b]) => a - b)
-          .map(([ch, val]) => `${ch}:${val}`)
-          .join(" ");
+        const preserved = safePositions.size + lockedChannels.size;
         pipeLog("info",
-          `WHITEOUT: set ${MAX_CHANNEL - safePositions.size} channels to 255, ` +
-          `preserved ${safePositions.size} motor channels: ${snapshot}`,
+          `WHITEOUT: set ${MAX_CHANNEL - preserved} channels to 255, ` +
+          `preserved ${safePositions.size} motor + ${lockedChannels.size} locked`,
         );
       } else {
         safeSend("whiteout", () => universe.updateAll(MAX_VALUE));
@@ -266,6 +300,24 @@ export function createUniverseManager(
         .map(([ch, val]) => `${ch}:${val}`)
         .join(" ");
       pipeLog("info", `Registered ${safePositions.size} motor safe positions: ${snapshot}`);
+    },
+
+    lockChannels(addresses: readonly number[]): void {
+      for (const addr of addresses) {
+        if (isValidChannel(addr)) {
+          lockedChannels.add(addr);
+        }
+      }
+    },
+
+    unlockChannels(addresses: readonly number[]): void {
+      for (const addr of addresses) {
+        lockedChannels.delete(addr);
+      }
+    },
+
+    hasLockedChannels(): boolean {
+      return lockedChannels.size > 0;
     },
   };
 }

--- a/server/src/routes/control.test.ts
+++ b/server/src/routes/control.test.ts
@@ -397,6 +397,118 @@ describe("Control routes", () => {
       expect(mockUniverse.updateCalls[0][74]).toBe(200);
     });
 
+    it("flash-click applies max brightness and returns 2s duration", async () => {
+      const addRes = await app.inject({
+        method: "POST",
+        url: "/fixtures",
+        payload: {
+          name: "Click PAR",
+          oflKey: "test/test",
+          oflFixtureName: "Test",
+          mode: "3-channel",
+          dmxStartAddress: 80,
+          channelCount: 3,
+          channels: [
+            { offset: 0, name: "Red", type: "ColorIntensity", color: "Red", defaultValue: 0 },
+            { offset: 1, name: "Green", type: "ColorIntensity", color: "Green", defaultValue: 0 },
+            { offset: 2, name: "Blue", type: "ColorIntensity", color: "Blue", defaultValue: 0 },
+          ],
+        },
+      });
+      const { id } = addRes.json();
+
+      const res = await app.inject({
+        method: "POST",
+        url: `/fixtures/${id}/test`,
+        payload: { action: "flash-click" },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().action).toBe("flash-click");
+      expect(res.json().durationMs).toBe(2000);
+
+      const lastUpdate = mockUniverse.updateCalls[mockUniverse.updateCalls.length - 1];
+      expect(lastUpdate[80]).toBe(255);
+      expect(lastUpdate[81]).toBe(255);
+      expect(lastUpdate[82]).toBe(255);
+    });
+
+    it("flash-click overrides active blackout via channel locking", async () => {
+      const addRes = await app.inject({
+        method: "POST",
+        url: "/fixtures",
+        payload: {
+          name: "Override PAR",
+          oflKey: "test/test",
+          oflFixtureName: "Test",
+          mode: "3-channel",
+          dmxStartAddress: 90,
+          channelCount: 3,
+          channels: [
+            { offset: 0, name: "Red", type: "ColorIntensity", color: "Red", defaultValue: 0 },
+            { offset: 1, name: "Green", type: "ColorIntensity", color: "Green", defaultValue: 0 },
+            { offset: 2, name: "Blue", type: "ColorIntensity", color: "Blue", defaultValue: 0 },
+          ],
+        },
+      });
+      const { id } = addRes.json();
+
+      // Activate blackout first
+      await app.inject({ method: "POST", url: "/control/blackout" });
+
+      // Flash-click should still work
+      const res = await app.inject({
+        method: "POST",
+        url: `/fixtures/${id}/test`,
+        payload: { action: "flash-click" },
+      });
+
+      expect(res.statusCode).toBe(200);
+
+      const lastUpdate = mockUniverse.updateCalls[mockUniverse.updateCalls.length - 1];
+      expect(lastUpdate[90]).toBe(255);
+      expect(lastUpdate[91]).toBe(255);
+      expect(lastUpdate[92]).toBe(255);
+    });
+
+    it("flash-click cancels existing flash-hold safety timer", async () => {
+      const addRes = await app.inject({
+        method: "POST",
+        url: "/fixtures",
+        payload: {
+          name: "Cancel PAR",
+          oflKey: "test/test",
+          oflFixtureName: "Test",
+          mode: "3-channel",
+          dmxStartAddress: 100,
+          channelCount: 3,
+          channels: [
+            { offset: 0, name: "Red", type: "ColorIntensity", color: "Red", defaultValue: 0 },
+            { offset: 1, name: "Green", type: "ColorIntensity", color: "Green", defaultValue: 0 },
+            { offset: 2, name: "Blue", type: "ColorIntensity", color: "Blue", defaultValue: 0 },
+          ],
+        },
+      });
+      const { id } = addRes.json();
+
+      // Start a hold
+      await app.inject({
+        method: "POST",
+        url: `/fixtures/${id}/test`,
+        payload: { action: "flash-hold" },
+      });
+
+      // Immediately send flash-click (should cancel hold timer)
+      const res = await app.inject({
+        method: "POST",
+        url: `/fixtures/${id}/test`,
+        payload: { action: "flash-click" },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().action).toBe("flash-click");
+    });
+
     it("flash-release with no active hold is a no-op", async () => {
       const addRes = await app.inject({
         method: "POST",

--- a/server/src/routes/control.ts
+++ b/server/src/routes/control.ts
@@ -36,7 +36,7 @@ interface ControlRouteDeps {
 }
 
 interface TestBody {
-  readonly action: "flash" | "flash-hold" | "flash-release" | "identify";
+  readonly action: "flash" | "flash-hold" | "flash-release" | "flash-click" | "identify";
   readonly durationMs?: number;
 }
 
@@ -47,7 +47,7 @@ const testSchema = {
     properties: {
       action: {
         type: "string" as const,
-        enum: ["flash", "flash-hold", "flash-release", "identify"],
+        enum: ["flash", "flash-hold", "flash-release", "flash-click", "identify"],
       },
       durationMs: { type: "integer" as const, minimum: 100, maximum: 5000 },
     },
@@ -55,6 +55,11 @@ const testSchema = {
 };
 
 const FLASH_HOLD_SAFETY_MS = 10_000;
+const FLASH_CLICK_SUSTAIN_MS = 2_000;
+
+function getFixtureAddresses(fixture: FixtureConfig): number[] {
+  return fixture.channels.map((ch) => fixture.dmxStartAddress + ch.offset);
+}
 
 export function registerControlRoutes(
   app: FastifyInstance,
@@ -63,19 +68,25 @@ export function registerControlRoutes(
   const activeTimers = new Map<string, NodeJS.Timeout>();
   const holdSnapshots = new Map<string, Record<number, number>>();
 
-  function restoreAfterFlash(
+  function releaseFlash(
     fixture: FixtureConfig,
     snapshot: Record<number, number>,
   ): void {
+    const addresses = getFixtureAddresses(fixture);
+    deps.manager.unlockChannels(addresses);
+
     if (deps.manager.isBlackoutActive()) {
+      // Deferred per-fixture blackout: now that flash is over, apply blackout
       const zeros: Record<number, number> = {};
-      for (const ch of fixture.channels) {
-        zeros[fixture.dmxStartAddress + ch.offset] = 0;
+      for (const addr of addresses) {
+        zeros[addr] = 0;
       }
       deps.manager.applyRawUpdate(zeros);
     } else {
       deps.manager.applyRawUpdate(snapshot);
     }
+
+    holdSnapshots.delete(fixture.id);
   }
 
   app.post("/control/blackout", async (request) => {
@@ -222,7 +233,7 @@ export function registerControlRoutes(
         );
 
         const timer = setTimeout(() => {
-          restoreAfterFlash(fixture, snapshot);
+          releaseFlash(fixture, snapshot);
           request.log.info(
             { action: "flash-restore", fixtureId: fixture.id },
             `flash-restore: "${fixture.name}" restored`,
@@ -240,19 +251,20 @@ export function registerControlRoutes(
         holdSnapshots.set(fixture.id, snapshot);
 
         const flashValues = buildFlashValues(fixture, snapshot);
+        const addresses = getFixtureAddresses(fixture);
         deps.manager.applyRawUpdate(flashValues);
+        deps.manager.lockChannels(addresses);
 
         request.log.info(
           { action, fixtureId: fixture.id, fixtureName: fixture.name },
-          `flash-hold: "${fixture.name}" held on`,
+          `flash-hold: "${fixture.name}" held on (${addresses.length} channels locked)`,
         );
 
         // Safety timeout in case browser disconnects mid-hold
         const safety = setTimeout(() => {
           const snap = holdSnapshots.get(fixture.id);
           if (snap !== undefined) {
-            restoreAfterFlash(fixture, snap);
-            holdSnapshots.delete(fixture.id);
+            releaseFlash(fixture, snap);
             request.log.warn(
               { fixtureId: fixture.id },
               `flash-hold safety timeout: "${fixture.name}" auto-restored`,
@@ -266,12 +278,38 @@ export function registerControlRoutes(
         return { success: true, action, fixtureId: fixture.id };
       }
 
+      if (action === "flash-click") {
+        const snapshot = deps.manager.getChannelSnapshot(start, count);
+        holdSnapshots.set(fixture.id, snapshot);
+
+        const flashValues = buildFlashValues(fixture, snapshot);
+        const addresses = getFixtureAddresses(fixture);
+        deps.manager.applyRawUpdate(flashValues);
+        deps.manager.lockChannels(addresses);
+
+        request.log.info(
+          { action, fixtureId: fixture.id, fixtureName: fixture.name },
+          `flash-click: "${fixture.name}" sustain ${FLASH_CLICK_SUSTAIN_MS}ms`,
+        );
+
+        const timer = setTimeout(() => {
+          const snap = holdSnapshots.get(fixture.id);
+          if (snap !== undefined) {
+            releaseFlash(fixture, snap);
+          }
+          activeTimers.delete(fixture.id);
+        }, FLASH_CLICK_SUSTAIN_MS);
+        timer.unref();
+        activeTimers.set(fixture.id, timer);
+
+        return { success: true, action, fixtureId: fixture.id, durationMs: FLASH_CLICK_SUSTAIN_MS };
+      }
+
       if (action === "flash-release") {
         const snapshot =
           holdSnapshots.get(fixture.id) ??
           deps.manager.getChannelSnapshot(start, count);
-        restoreAfterFlash(fixture, snapshot);
-        holdSnapshots.delete(fixture.id);
+        releaseFlash(fixture, snapshot);
 
         request.log.info(
           { action, fixtureId: fixture.id, fixtureName: fixture.name },


### PR DESCRIPTION
## Summary
- Adds click-to-flash (2s server-side sustain) alongside existing hold-to-flash behavior — short click (<200ms) triggers `flash-click`, longer hold uses `flash-hold`/`flash-release`
- Introduces channel locking in `UniverseManager` so flash values override blackout/whiteout/UDP color updates while active
- Deferred per-fixture blackout: when flash ends during active blackout, the fixture's channels are properly zeroed
- 9 new tests covering channel locking, flash-click sustain, blackout override, and timer cancellation

### Channel locking mechanism
- `lockChannels()` / `unlockChannels()` on `UniverseManager` prevent `applyFixtureUpdate()`, `blackout()`, and `whiteout()` from overwriting locked addresses
- Flash operations lock fixture DMX addresses, ensuring SignalRGB color data and blackout/whiteout can't interrupt a flash

## Test plan
- [x] 499 tests pass (9 new), 9 skipped
- [ ] Manual: click flash quickly → light on for 2s, then restores
- [ ] Manual: hold flash → light on while held, off on release
- [ ] Manual: click flash then press Blackout → flashed fixture stays lit for 2s, others go dark
- [ ] Manual: during flash, SignalRGB color data doesn't overwrite flash values

Closes #19