### PR TITLE
feat: custom fixture builder

### DIFF
--- a/server/public/css/style.css
+++ b/server/public/css/style.css
@@ -1094,3 +1094,132 @@ header {
   color: var(--text-dim);
   font-weight: normal;
 }
+
+/* ── Custom Fixture Builder ── */
+
+.tab-custom {
+  border-bottom-color: var(--accent) !important;
+}
+
+.btn-block {
+  display: block;
+  width: 100%;
+  margin-bottom: 0.5rem;
+}
+
+.custom-template-list {
+  margin-top: 0.5rem;
+}
+
+.custom-template-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.custom-template-item:hover {
+  background: var(--surface2);
+}
+
+.custom-template-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.custom-template-info strong {
+  display: block;
+  font-size: 0.85rem;
+}
+
+.custom-template-meta {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+}
+
+.custom-template-actions {
+  display: flex;
+  gap: 0.25rem;
+  flex-shrink: 0;
+}
+
+.channel-builder {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin: 0.5rem 0;
+}
+
+.channel-row {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.3rem;
+  background: var(--surface2);
+  border-radius: 4px;
+  flex-wrap: wrap;
+}
+
+.channel-offset {
+  width: 1.5rem;
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  flex-shrink: 0;
+}
+
+.channel-name-input {
+  flex: 1;
+  min-width: 60px;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.35rem;
+}
+
+.channel-type-select {
+  width: 110px;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.2rem;
+}
+
+.channel-color-select {
+  width: 70px;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.2rem;
+}
+
+.channel-default-input {
+  width: 48px;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.2rem;
+  text-align: center;
+}
+
+.channel-row-actions {
+  display: flex;
+  gap: 0.15rem;
+  flex-shrink: 0;
+}
+
+.channel-row-actions .btn {
+  padding: 0.1rem 0.3rem;
+  font-size: 0.75rem;
+  min-width: 0;
+}
+
+.review-summary {
+  margin: 0.5rem 0;
+  font-size: 0.85rem;
+}
+
+.review-row {
+  padding: 0.15rem 0;
+}
+
+.review-label {
+  color: var(--text-dim);
+  display: inline-block;
+  min-width: 90px;
+}

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -16,6 +16,7 @@
   <script src="/js/settings.js"></script>
   <script src="/js/latency.js"></script>
   <script src="/js/setup-wizard.js"></script>
+  <script src="/js/custom-fixture.js"></script>
   <script src="/js/app.js"></script>
 </head>
 <body x-data="dmxrApp()" x-init="init()">
@@ -101,10 +102,12 @@
         <div class="source-tabs">
           <button class="tab" :class="{ active: browseSource === 'ofl' }"
                   @click="switchBrowseSource('ofl')">OFL</button>
-          <template x-for="lib in getNonOflLibraries()" :key="lib.id">
+          <template x-for="lib in getNonOflLibraries().filter(l => l.id !== 'custom')" :key="lib.id">
             <button class="tab" :class="{ active: browseSource === lib.id }"
                     @click="switchBrowseSource(lib.id)" x-text="lib.displayName"></button>
           </template>
+          <button class="tab tab-custom" :class="{ active: browseSource === 'custom' }"
+                  @click="switchBrowseSource('custom'); loadCustomTemplates()">Custom</button>
         </div>
 
         <!-- OFL Browse -->
@@ -163,8 +166,129 @@
           </div>
         </template>
 
+        <!-- Custom Fixture Builder -->
+        <template x-if="browseSource === 'custom'">
+          <div>
+            <!-- Step 0: Template list -->
+            <div x-show="customStep === 0">
+              <button class="btn btn-primary btn-block" @click="startCustomCreate()">+ Create New Fixture</button>
+              <div class="custom-template-list" x-show="customTemplates.length > 0">
+                <template x-for="tpl in customTemplates" :key="tpl.id">
+                  <div class="custom-template-item">
+                    <div class="custom-template-info" @click="stageCustomTemplate(tpl)">
+                      <strong x-text="tpl.name"></strong>
+                      <span class="custom-template-meta"
+                            x-text="tpl.manufacturer + ' &middot; ' + (tpl.modes[0]?.channels.length || 0) + ' ch'"></span>
+                    </div>
+                    <div class="custom-template-actions">
+                      <button class="btn btn-sm" @click.stop="startCustomEdit(tpl)" title="Edit">&#9998;</button>
+                      <button class="btn btn-sm btn-danger" @click.stop="deleteCustomTemplate(tpl.id)" title="Delete">&times;</button>
+                    </div>
+                  </div>
+                </template>
+              </div>
+              <div class="sidebar-hint" x-show="customTemplates.length === 0">
+                No custom fixtures yet. Create one to get started.
+              </div>
+            </div>
+
+            <!-- Step 1: Fixture Info -->
+            <div x-show="customStep === 1">
+              <button class="btn btn-sm btn-back" @click="customStep = 0">&larr; My Fixtures</button>
+              <h4 x-text="customEditId ? 'Edit Fixture' : 'New Custom Fixture'"></h4>
+              <p class="validation-error" x-show="customError" x-text="customError"></p>
+
+              <label>Fixture Name</label>
+              <input type="text" x-model="customName" placeholder="e.g. My RGB PAR">
+
+              <label>Manufacturer</label>
+              <input type="text" x-model="customManufacturer" placeholder="e.g. DIY">
+
+              <label>Category</label>
+              <select x-model="customCategory">
+                <template x-for="cat in fixtureCategories" :key="cat">
+                  <option :value="cat" x-text="cat"></option>
+                </template>
+              </select>
+
+              <button class="btn btn-primary" @click="customInfoNext()">Next: Channels</button>
+            </div>
+
+            <!-- Step 2: Channel Builder -->
+            <div x-show="customStep === 2">
+              <button class="btn btn-sm btn-back" @click="customStep = 1">&larr; Info</button>
+              <h4>Channel Builder</h4>
+              <p class="validation-error" x-show="customError" x-text="customError"></p>
+
+              <label>Mode Name</label>
+              <input type="text" x-model="customModeName" :placeholder="customChannels.length + '-channel'">
+
+              <div class="channel-builder">
+                <template x-for="(ch, idx) in customChannels" :key="idx">
+                  <div class="channel-row">
+                    <span class="channel-offset" x-text="idx + 1"></span>
+                    <input type="text" class="channel-name-input" x-model="customChannels[idx].name"
+                           placeholder="Channel name">
+                    <select class="channel-type-select" x-model="customChannels[idx].type"
+                            @change="onCustomTypeChange(idx)">
+                      <template x-for="t in channelTypes" :key="t">
+                        <option :value="t" x-text="t"></option>
+                      </template>
+                    </select>
+                    <select class="channel-color-select" x-model="customChannels[idx].color"
+                            x-show="customChannels[idx].type === 'ColorIntensity'">
+                      <template x-for="c in channelColors" :key="c">
+                        <option :value="c" x-text="c"></option>
+                      </template>
+                    </select>
+                    <input type="number" class="channel-default-input" x-model.number="customChannels[idx].defaultValue"
+                           min="0" max="255" title="Default value (0-255)">
+                    <div class="channel-row-actions">
+                      <button class="btn btn-sm" @click="moveCustomChannel(idx, -1)"
+                              :disabled="idx === 0" title="Move up">&uarr;</button>
+                      <button class="btn btn-sm" @click="moveCustomChannel(idx, 1)"
+                              :disabled="idx === customChannels.length - 1" title="Move down">&darr;</button>
+                      <button class="btn btn-sm btn-danger" @click="removeCustomChannel(idx)" title="Remove">&times;</button>
+                    </div>
+                  </div>
+                </template>
+              </div>
+
+              <button class="btn btn-sm" @click="addCustomChannel()">+ Add Channel</button>
+
+              <button class="btn btn-primary" @click="customChannelsNext()"
+                      :disabled="customChannels.length === 0"
+                      style="margin-top: 0.5rem">Next: Review</button>
+            </div>
+
+            <!-- Step 3: Review -->
+            <div x-show="customStep === 3">
+              <button class="btn btn-sm btn-back" @click="customStep = 2">&larr; Channels</button>
+              <h4>Review</h4>
+              <p class="validation-error" x-show="customError" x-text="customError"></p>
+
+              <div class="review-summary">
+                <div class="review-row"><span class="review-label">Name:</span> <span x-text="customName"></span></div>
+                <div class="review-row"><span class="review-label">Manufacturer:</span> <span x-text="customManufacturer"></span></div>
+                <div class="review-row"><span class="review-label">Category:</span> <span x-text="customCategory"></span></div>
+                <div class="review-row"><span class="review-label">Mode:</span> <span x-text="customModeName || (customChannels.length + '-channel')"></span></div>
+                <div class="review-row"><span class="review-label">Channels:</span> <span x-text="customChannels.length"></span></div>
+              </div>
+
+              <div class="channel-preview">
+                <template x-for="ch in customChannels" :key="ch.offset">
+                  <span class="badge" :class="'badge-' + (ch.color || ch.type).toLowerCase()"
+                        x-text="ch.name + ' (' + ch.type + ')'"></span>
+                </template>
+              </div>
+
+              <button class="btn btn-primary btn-stage" @click="saveCustomFixture()">Save &amp; Stage</button>
+            </div>
+          </div>
+        </template>
+
         <!-- Library Browse (non-OFL) -->
-        <template x-if="browseSource !== 'ofl'">
+        <template x-if="browseSource !== 'ofl' && browseSource !== 'custom'">
           <div>
             <template x-if="!isLibAvailable(browseSource) && getLibStatus(browseSource)">
               <div class="library-status-message">

--- a/server/public/js/app.js
+++ b/server/public/js/app.js
@@ -65,6 +65,7 @@ function dmxrApp() {
       await this.loadFixtures();
       await this.loadManufacturers();
       await this.loadLibraries();
+      await this.loadCustomTemplates();
       this.loadServerName();
       this.pollFixtures();
       await this.checkWizardNeeded();
@@ -80,5 +81,6 @@ function dmxrApp() {
     dmxrSettings(),
     dmxrLatency(),
     dmxrSetupWizard(),
+    dmxrCustomFixture(),
   );
 }

--- a/server/public/js/custom-fixture.js
+++ b/server/public/js/custom-fixture.js
@@ -1,0 +1,274 @@
+/**
+ * Custom fixture builder mixin for DMXr.
+ * Mixed into the main Alpine component via Object.assign.
+ */
+
+var CHANNEL_TYPES = [
+  "ColorIntensity",
+  "Intensity",
+  "Strobe",
+  "ShutterStrobe",
+  "Pan",
+  "Tilt",
+  "Focus",
+  "Zoom",
+  "Gobo",
+  "Iris",
+  "Prism",
+  "ColorWheel",
+  "NoFunction",
+  "Generic",
+];
+
+var CHANNEL_COLORS = ["Red", "Green", "Blue", "White", "Amber", "UV", "Cyan", "Magenta", "Yellow"];
+
+var FIXTURE_CATEGORIES = [
+  "Color Changer",
+  "Moving Head",
+  "Scanner",
+  "Dimmer",
+  "Strobe",
+  "Blinder",
+  "Laser",
+  "Effect",
+  "Pixel Bar",
+  "Other",
+];
+
+function dmxrCustomFixture() {
+  return {
+    // Custom fixture state
+    customStep: 0,       // 0=list, 1=info, 2=channels, 3=review
+    customTemplates: [],
+    customName: "",
+    customManufacturer: "",
+    customCategory: "Color Changer",
+    customModeName: "",
+    customChannels: [],
+    customError: "",
+    customEditId: null,
+
+    // Constants exposed for templates
+    channelTypes: CHANNEL_TYPES,
+    channelColors: CHANNEL_COLORS,
+    fixtureCategories: FIXTURE_CATEGORIES,
+
+    async loadCustomTemplates() {
+      try {
+        var res = await fetch("/user-fixtures");
+        if (res.ok) {
+          this.customTemplates = await res.json();
+        }
+      } catch {
+        this.customTemplates = [];
+      }
+    },
+
+    startCustomCreate() {
+      this.customEditId = null;
+      this.customName = "";
+      this.customManufacturer = "";
+      this.customCategory = "Color Changer";
+      this.customModeName = "";
+      this.customChannels = [];
+      this.customError = "";
+      this.customStep = 1;
+    },
+
+    startCustomEdit(template) {
+      this.customEditId = template.id;
+      this.customName = template.name;
+      this.customManufacturer = template.manufacturer;
+      this.customCategory = template.category;
+      // Load first mode for editing
+      var mode = template.modes[0];
+      this.customModeName = mode ? mode.name : "";
+      this.customChannels = mode ? mode.channels.map(function(ch) {
+        return {
+          offset: ch.offset,
+          name: ch.name,
+          type: ch.type,
+          color: ch.color || "",
+          defaultValue: ch.defaultValue,
+        };
+      }) : [];
+      this.customError = "";
+      this.customStep = 1;
+    },
+
+    customInfoNext() {
+      if (!this.customName.trim()) {
+        this.customError = "Name is required";
+        return;
+      }
+      if (!this.customManufacturer.trim()) {
+        this.customError = "Manufacturer is required";
+        return;
+      }
+      this.customError = "";
+      if (this.customChannels.length === 0) {
+        this.addCustomChannel();
+      }
+      if (!this.customModeName) {
+        this.customModeName = this.customChannels.length + "-channel";
+      }
+      this.customStep = 2;
+    },
+
+    addCustomChannel() {
+      var offset = this.customChannels.length;
+      this.customChannels = this.customChannels.concat([{
+        offset: offset,
+        name: "",
+        type: "ColorIntensity",
+        color: "Red",
+        defaultValue: 0,
+      }]);
+    },
+
+    removeCustomChannel(index) {
+      this.customChannels = this.customChannels
+        .filter(function(_, i) { return i !== index; })
+        .map(function(ch, i) { return Object.assign({}, ch, { offset: i }); });
+    },
+
+    moveCustomChannel(index, direction) {
+      var newIndex = index + direction;
+      if (newIndex < 0 || newIndex >= this.customChannels.length) return;
+      var arr = this.customChannels.slice();
+      var temp = arr[index];
+      arr[index] = arr[newIndex];
+      arr[newIndex] = temp;
+      this.customChannels = arr.map(function(ch, i) {
+        return Object.assign({}, ch, { offset: i });
+      });
+    },
+
+    onCustomTypeChange(index) {
+      var ch = this.customChannels[index];
+      if (ch.type !== "ColorIntensity") {
+        this.customChannels = this.customChannels.map(function(c, i) {
+          return i === index ? Object.assign({}, c, { color: "" }) : c;
+        });
+      } else if (!ch.color) {
+        this.customChannels = this.customChannels.map(function(c, i) {
+          return i === index ? Object.assign({}, c, { color: "Red" }) : c;
+        });
+      }
+      // Auto-name if empty
+      if (!ch.name) {
+        var autoName = ch.type === "ColorIntensity" ? ch.color : ch.type;
+        this.customChannels = this.customChannels.map(function(c, i) {
+          return i === index ? Object.assign({}, c, { name: autoName || "" }) : c;
+        });
+      }
+    },
+
+    customChannelsNext() {
+      if (this.customChannels.length === 0) {
+        this.customError = "Add at least one channel";
+        return;
+      }
+      for (var i = 0; i < this.customChannels.length; i++) {
+        if (!this.customChannels[i].name.trim()) {
+          this.customError = "Channel " + (i + 1) + " needs a name";
+          return;
+        }
+      }
+      if (!this.customModeName.trim()) {
+        this.customModeName = this.customChannels.length + "-channel";
+      }
+      this.customError = "";
+      this.customStep = 3;
+    },
+
+    async saveCustomFixture() {
+      this.customError = "";
+
+      var channels = this.customChannels.map(function(ch) {
+        var out = {
+          offset: ch.offset,
+          name: ch.name,
+          type: ch.type,
+          defaultValue: ch.defaultValue,
+        };
+        if (ch.type === "ColorIntensity" && ch.color) {
+          out.color = ch.color;
+        }
+        return out;
+      });
+
+      var payload = {
+        name: this.customName.trim(),
+        manufacturer: this.customManufacturer.trim(),
+        category: this.customCategory,
+        modes: [{
+          name: this.customModeName.trim() || (channels.length + "-channel"),
+          channels: channels,
+        }],
+      };
+
+      try {
+        var url = this.customEditId
+          ? "/user-fixtures/" + this.customEditId
+          : "/user-fixtures";
+        var method = this.customEditId ? "PATCH" : "POST";
+
+        var res = await fetch(url, {
+          method: method,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+
+        if (!res.ok) {
+          var data = await res.json();
+          this.customError = data.error || "Save failed";
+          return;
+        }
+
+        var saved = await res.json();
+        await this.loadCustomTemplates();
+        await this.loadLibraries();
+
+        // Auto-stage for grid placement
+        var mode = saved.modes[0];
+        this.stagedFixture = {
+          name: saved.name,
+          source: "custom",
+          mode: mode.name,
+          channelCount: mode.channels.length,
+          channels: mode.channels,
+        };
+        this.customStep = 0;
+      } catch (err) {
+        this.customError = "Network error saving fixture";
+      }
+    },
+
+    async deleteCustomTemplate(id) {
+      try {
+        var res = await fetch("/user-fixtures/" + id, { method: "DELETE" });
+        if (res.ok) {
+          await this.loadCustomTemplates();
+          await this.loadLibraries();
+        }
+      } catch {
+        // ignore
+      }
+    },
+
+    stageCustomTemplate(template) {
+      var mode = template.modes[0];
+      if (!mode) return;
+
+      this.fixtureName = template.name;
+      this.stagedFixture = {
+        name: template.name,
+        source: "custom",
+        mode: mode.name,
+        channelCount: mode.channels.length,
+        channels: mode.channels,
+      };
+    },
+  };
+}

--- a/server/src/config/server-config.ts
+++ b/server/src/config/server-config.ts
@@ -12,6 +12,7 @@ export interface ServerConfig {
   readonly mdnsEnabled: boolean;
   readonly portRangeSize: number;
   readonly localDbPath?: string;
+  readonly userFixturesPath: string;
   readonly corsOrigin?: string;
   readonly apiKey?: string;
 }
@@ -72,6 +73,7 @@ export function loadConfig(
       process.env["DMX_DEVICE_PATH"] ?? base.dmxDevicePath ?? "auto",
     logLevel: process.env["LOG_LEVEL"] ?? "info",
     fixturesPath: process.env["FIXTURES_PATH"] ?? "./config/fixtures.json",
+    userFixturesPath: process.env["USER_FIXTURES_PATH"] ?? "./config/user-fixtures.json",
     mdnsEnabled:
       process.env["MDNS_ENABLED"] !== undefined
         ? process.env["MDNS_ENABLED"] !== "false"

--- a/server/src/fixtures/user-fixture-store.test.ts
+++ b/server/src/fixtures/user-fixture-store.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createUserFixtureStore } from "./user-fixture-store.js";
+import type { UserFixtureStore } from "./user-fixture-store.js";
+import type { CreateUserFixtureRequest } from "./user-fixture-types.js";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+function makeRequest(
+  overrides: Partial<CreateUserFixtureRequest> = {},
+): CreateUserFixtureRequest {
+  return {
+    name: "My Custom PAR",
+    manufacturer: "DIY",
+    category: "Color Changer",
+    modes: [
+      {
+        name: "3-channel",
+        channels: [
+          { offset: 0, name: "Red", type: "ColorIntensity", color: "Red", defaultValue: 0 },
+          { offset: 1, name: "Green", type: "ColorIntensity", color: "Green", defaultValue: 0 },
+          { offset: 2, name: "Blue", type: "ColorIntensity", color: "Blue", defaultValue: 0 },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("createUserFixtureStore", () => {
+  let store: UserFixtureStore;
+  let filePath: string;
+
+  beforeEach(() => {
+    filePath = join(tmpdir(), `dmxr-user-fixtures-test-${Date.now()}.json`);
+    store = createUserFixtureStore(filePath);
+  });
+
+  afterEach(async () => {
+    store.dispose();
+    try {
+      await rm(filePath);
+    } catch {
+      // file may not exist
+    }
+  });
+
+  describe("getAll", () => {
+    it("returns empty array initially", () => {
+      expect(store.getAll()).toEqual([]);
+    });
+  });
+
+  describe("add", () => {
+    it("creates a template with generated id and timestamps", () => {
+      const template = store.add(makeRequest());
+
+      expect(template.id).toBeDefined();
+      expect(template.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      expect(template.name).toBe("My Custom PAR");
+      expect(template.manufacturer).toBe("DIY");
+      expect(template.category).toBe("Color Changer");
+      expect(template.createdAt).toBeDefined();
+      expect(template.updatedAt).toBeDefined();
+    });
+
+    it("generates ids for each mode", () => {
+      const template = store.add(
+        makeRequest({
+          modes: [
+            { name: "3ch", channels: [{ offset: 0, name: "Red", type: "ColorIntensity", color: "Red", defaultValue: 0 }] },
+            { name: "7ch", channels: [{ offset: 0, name: "Red", type: "ColorIntensity", color: "Red", defaultValue: 0 }] },
+          ],
+        }),
+      );
+
+      expect(template.modes).toHaveLength(2);
+      expect(template.modes[0].id).toBeDefined();
+      expect(template.modes[1].id).toBeDefined();
+      expect(template.modes[0].id).not.toBe(template.modes[1].id);
+    });
+
+    it("adds template to the store", () => {
+      store.add(makeRequest());
+      expect(store.getAll()).toHaveLength(1);
+    });
+
+    it("preserves existing templates when adding", () => {
+      store.add(makeRequest({ name: "First" }));
+      store.add(makeRequest({ name: "Second" }));
+      expect(store.getAll()).toHaveLength(2);
+    });
+  });
+
+  describe("getById", () => {
+    it("returns template by id", () => {
+      const added = store.add(makeRequest());
+      const found = store.getById(added.id);
+      expect(found).toEqual(added);
+    });
+
+    it("returns undefined for unknown id", () => {
+      expect(store.getById("nonexistent")).toBeUndefined();
+    });
+  });
+
+  describe("update", () => {
+    it("merges partial update and bumps updatedAt", async () => {
+      const template = store.add(makeRequest({ name: "Old Name" }));
+      const originalUpdatedAt = template.updatedAt;
+
+      // Ensure time advances
+      await new Promise((r) => setTimeout(r, 5));
+
+      const updated = store.update(template.id, { name: "New Name" });
+
+      expect(updated).toBeDefined();
+      expect(updated!.name).toBe("New Name");
+      expect(updated!.manufacturer).toBe("DIY");
+      expect(updated!.id).toBe(template.id);
+      expect(updated!.createdAt).toBe(template.createdAt);
+      expect(updated!.updatedAt).not.toBe(originalUpdatedAt);
+    });
+
+    it("updates modes with new ids", () => {
+      const template = store.add(makeRequest());
+      const updated = store.update(template.id, {
+        modes: [
+          { name: "1ch", channels: [{ offset: 0, name: "Dimmer", type: "Intensity", defaultValue: 0 }] },
+        ],
+      });
+
+      expect(updated!.modes).toHaveLength(1);
+      expect(updated!.modes[0].name).toBe("1ch");
+      expect(updated!.modes[0].id).toBeDefined();
+    });
+
+    it("returns undefined for unknown id", () => {
+      expect(store.update("nonexistent", { name: "X" })).toBeUndefined();
+    });
+
+    it("does not mutate original array", () => {
+      const template = store.add(makeRequest());
+      const allBefore = store.getAll();
+
+      store.update(template.id, { name: "Changed" });
+
+      const allAfter = store.getAll();
+      expect(allBefore).not.toBe(allAfter);
+    });
+  });
+
+  describe("remove", () => {
+    it("removes template and returns true", () => {
+      const template = store.add(makeRequest());
+      const removed = store.remove(template.id);
+
+      expect(removed).toBe(true);
+      expect(store.getAll()).toHaveLength(0);
+    });
+
+    it("returns false for unknown id", () => {
+      expect(store.remove("nonexistent")).toBe(false);
+    });
+
+    it("does not affect other templates", () => {
+      const first = store.add(makeRequest({ name: "First" }));
+      store.add(makeRequest({ name: "Second" }));
+
+      store.remove(first.id);
+
+      expect(store.getAll()).toHaveLength(1);
+      expect(store.getAll()[0].name).toBe("Second");
+    });
+  });
+
+  describe("save and load", () => {
+    it("round-trips templates to disk", async () => {
+      store.add(makeRequest({ name: "Saved PAR" }));
+      await store.save();
+
+      const store2 = createUserFixtureStore(filePath);
+      await store2.load();
+
+      expect(store2.getAll()).toHaveLength(1);
+      expect(store2.getAll()[0].name).toBe("Saved PAR");
+      store2.dispose();
+    });
+
+    it("loads empty array when file missing", async () => {
+      const missingStore = createUserFixtureStore("/tmp/does-not-exist-user.json");
+      await missingStore.load();
+
+      expect(missingStore.getAll()).toEqual([]);
+      missingStore.dispose();
+    });
+
+    it("loads empty array for invalid JSON", async () => {
+      const { writeFile, mkdir } = await import("node:fs/promises");
+      const { dirname } = await import("node:path");
+      await mkdir(dirname(filePath), { recursive: true });
+      await writeFile(filePath, "not json", "utf-8");
+
+      await store.load();
+      expect(store.getAll()).toEqual([]);
+    });
+
+    it("persists updates across load cycles", async () => {
+      const template = store.add(makeRequest({ name: "Before" }));
+      store.update(template.id, { name: "After" });
+      await store.save();
+
+      const store2 = createUserFixtureStore(filePath);
+      await store2.load();
+
+      expect(store2.getById(template.id)!.name).toBe("After");
+      store2.dispose();
+    });
+  });
+
+  describe("immutability", () => {
+    it("add creates new array — old reference is stale", () => {
+      store.add(makeRequest({ name: "First" }));
+      const before = store.getAll();
+
+      store.add(makeRequest({ name: "Second" }));
+      const after = store.getAll();
+
+      expect(before).not.toBe(after);
+      expect(before).toHaveLength(1);
+      expect(after).toHaveLength(2);
+    });
+
+    it("getById returns matching template", () => {
+      const added = store.add(makeRequest());
+      const found = store.getById(added.id);
+
+      expect(found).toEqual(added);
+    });
+  });
+});

--- a/server/src/fixtures/user-fixture-store.ts
+++ b/server/src/fixtures/user-fixture-store.ts
@@ -1,0 +1,150 @@
+import { readFile, writeFile, mkdir, rename } from "node:fs/promises";
+import { dirname } from "node:path";
+import { randomUUID } from "node:crypto";
+import type {
+  UserFixtureTemplate,
+  UserFixtureMode,
+  CreateUserFixtureRequest,
+  UpdateUserFixtureRequest,
+} from "./user-fixture-types.js";
+
+export interface UserFixtureStore {
+  readonly getAll: () => readonly UserFixtureTemplate[];
+  readonly getById: (id: string) => UserFixtureTemplate | undefined;
+  readonly add: (request: CreateUserFixtureRequest) => UserFixtureTemplate;
+  readonly update: (id: string, changes: UpdateUserFixtureRequest) => UserFixtureTemplate | undefined;
+  readonly remove: (id: string) => boolean;
+  readonly save: () => Promise<void>;
+  readonly scheduleSave: () => void;
+  readonly load: () => Promise<void>;
+  readonly dispose: () => void;
+}
+
+function isValidTemplateArray(data: unknown): data is UserFixtureTemplate[] {
+  if (!Array.isArray(data)) return false;
+
+  return data.every(
+    (item) =>
+      typeof item === "object" &&
+      item !== null &&
+      typeof item.id === "string" &&
+      typeof item.name === "string" &&
+      typeof item.manufacturer === "string" &&
+      Array.isArray(item.modes),
+  );
+}
+
+function buildModes(
+  rawModes: readonly { readonly name: string; readonly channels: readonly import("../types/protocol.js").FixtureChannel[] }[],
+): UserFixtureMode[] {
+  return rawModes.map((m) => ({
+    id: randomUUID(),
+    name: m.name,
+    channels: [...m.channels],
+  }));
+}
+
+const SAVE_DEBOUNCE_MS = 250;
+
+export function createUserFixtureStore(filePath: string): UserFixtureStore {
+  let templates: UserFixtureTemplate[] = [];
+  let saveChain: Promise<void> = Promise.resolve();
+  let saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+  return {
+    getAll(): readonly UserFixtureTemplate[] {
+      return templates;
+    },
+
+    getById(id: string): UserFixtureTemplate | undefined {
+      return templates.find((t) => t.id === id);
+    },
+
+    add(request: CreateUserFixtureRequest): UserFixtureTemplate {
+      const now = new Date().toISOString();
+      const template: UserFixtureTemplate = {
+        id: randomUUID(),
+        name: request.name,
+        manufacturer: request.manufacturer,
+        category: request.category,
+        modes: buildModes(request.modes),
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      templates = [...templates, template];
+      return template;
+    },
+
+    update(
+      id: string,
+      changes: UpdateUserFixtureRequest,
+    ): UserFixtureTemplate | undefined {
+      const index = templates.findIndex((t) => t.id === id);
+      if (index === -1) return undefined;
+
+      const existing = templates[index];
+      const updated: UserFixtureTemplate = {
+        ...existing,
+        ...(changes.name !== undefined ? { name: changes.name } : {}),
+        ...(changes.manufacturer !== undefined ? { manufacturer: changes.manufacturer } : {}),
+        ...(changes.category !== undefined ? { category: changes.category } : {}),
+        ...(changes.modes !== undefined ? { modes: buildModes(changes.modes) } : {}),
+        updatedAt: new Date().toISOString(),
+      };
+
+      templates = templates.map((t, i) => (i === index ? updated : t));
+      return updated;
+    },
+
+    remove(id: string): boolean {
+      const before = templates.length;
+      templates = templates.filter((t) => t.id !== id);
+      return templates.length < before;
+    },
+
+    async save(): Promise<void> {
+      saveChain = saveChain.then(async () => {
+        await mkdir(dirname(filePath), { recursive: true });
+        const tmpPath = filePath + ".tmp";
+        await writeFile(tmpPath, JSON.stringify(templates, null, 2), "utf-8");
+        await rename(tmpPath, filePath);
+      });
+      return saveChain;
+    },
+
+    scheduleSave(): void {
+      if (saveTimer !== null) {
+        clearTimeout(saveTimer);
+      }
+      saveTimer = setTimeout(() => {
+        saveTimer = null;
+        this.save().catch(() => {
+          // best-effort persistence
+        });
+      }, SAVE_DEBOUNCE_MS);
+    },
+
+    dispose(): void {
+      if (saveTimer !== null) {
+        clearTimeout(saveTimer);
+        saveTimer = null;
+      }
+    },
+
+    async load(): Promise<void> {
+      try {
+        const data = await readFile(filePath, "utf-8");
+        const parsed: unknown = JSON.parse(data);
+
+        if (isValidTemplateArray(parsed)) {
+          templates = parsed;
+        } else {
+          templates = [];
+        }
+      } catch {
+        templates = [];
+      }
+    },
+  };
+}

--- a/server/src/fixtures/user-fixture-types.ts
+++ b/server/src/fixtures/user-fixture-types.ts
@@ -1,0 +1,37 @@
+import type { FixtureChannel } from "../types/protocol.js";
+
+export interface UserFixtureMode {
+  readonly id: string;
+  readonly name: string;
+  readonly channels: readonly FixtureChannel[];
+}
+
+export interface UserFixtureTemplate {
+  readonly id: string;
+  readonly name: string;
+  readonly manufacturer: string;
+  readonly category: string;
+  readonly modes: readonly UserFixtureMode[];
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface CreateUserFixtureRequest {
+  readonly name: string;
+  readonly manufacturer: string;
+  readonly category: string;
+  readonly modes: readonly {
+    readonly name: string;
+    readonly channels: readonly FixtureChannel[];
+  }[];
+}
+
+export interface UpdateUserFixtureRequest {
+  readonly name?: string;
+  readonly manufacturer?: string;
+  readonly category?: string;
+  readonly modes?: readonly {
+    readonly name: string;
+    readonly channels: readonly FixtureChannel[];
+  }[];
+}

--- a/server/src/fixtures/user-fixture-validator.test.ts
+++ b/server/src/fixtures/user-fixture-validator.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import { validateUserFixtureTemplate } from "./user-fixture-validator.js";
+import type { CreateUserFixtureRequest } from "./user-fixture-types.js";
+
+function makeRequest(
+  overrides: Partial<CreateUserFixtureRequest> = {},
+): CreateUserFixtureRequest {
+  return {
+    name: "My PAR",
+    manufacturer: "DIY",
+    category: "Color Changer",
+    modes: [
+      {
+        name: "3-channel",
+        channels: [
+          { offset: 0, name: "Red", type: "ColorIntensity", color: "Red", defaultValue: 0 },
+          { offset: 1, name: "Green", type: "ColorIntensity", color: "Green", defaultValue: 0 },
+          { offset: 2, name: "Blue", type: "ColorIntensity", color: "Blue", defaultValue: 0 },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("validateUserFixtureTemplate", () => {
+  it("accepts a valid template", () => {
+    const result = validateUserFixtureTemplate(makeRequest());
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepts a valid multi-mode template", () => {
+    const result = validateUserFixtureTemplate(
+      makeRequest({
+        modes: [
+          {
+            name: "3ch",
+            channels: [
+              { offset: 0, name: "Red", type: "ColorIntensity", color: "Red", defaultValue: 0 },
+              { offset: 1, name: "Green", type: "ColorIntensity", color: "Green", defaultValue: 0 },
+              { offset: 2, name: "Blue", type: "ColorIntensity", color: "Blue", defaultValue: 0 },
+            ],
+          },
+          {
+            name: "7ch",
+            channels: [
+              { offset: 0, name: "Red", type: "ColorIntensity", color: "Red", defaultValue: 0 },
+              { offset: 1, name: "Green", type: "ColorIntensity", color: "Green", defaultValue: 0 },
+              { offset: 2, name: "Blue", type: "ColorIntensity", color: "Blue", defaultValue: 0 },
+              { offset: 3, name: "Dimmer", type: "Intensity", defaultValue: 255 },
+              { offset: 4, name: "Strobe", type: "Strobe", defaultValue: 0 },
+              { offset: 5, name: "Color Macro", type: "ColorWheel", defaultValue: 0 },
+              { offset: 6, name: "Mode", type: "NoFunction", defaultValue: 0 },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects empty name", () => {
+    const result = validateUserFixtureTemplate(makeRequest({ name: "" }));
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/name/i);
+  });
+
+  it("rejects whitespace-only name", () => {
+    const result = validateUserFixtureTemplate(makeRequest({ name: "   " }));
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/name/i);
+  });
+
+  it("rejects empty manufacturer", () => {
+    const result = validateUserFixtureTemplate(makeRequest({ manufacturer: "" }));
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/manufacturer/i);
+  });
+
+  it("rejects zero modes", () => {
+    const result = validateUserFixtureTemplate(makeRequest({ modes: [] }));
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/mode/i);
+  });
+
+  it("rejects mode with empty name", () => {
+    const result = validateUserFixtureTemplate(
+      makeRequest({
+        modes: [
+          {
+            name: "",
+            channels: [{ offset: 0, name: "Dimmer", type: "Intensity", defaultValue: 0 }],
+          },
+        ],
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/mode.*name/i);
+  });
+
+  it("rejects mode with zero channels", () => {
+    const result = validateUserFixtureTemplate(
+      makeRequest({
+        modes: [{ name: "Empty", channels: [] }],
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/channel/i);
+  });
+
+  it("rejects duplicate channel offsets within a mode", () => {
+    const result = validateUserFixtureTemplate(
+      makeRequest({
+        modes: [
+          {
+            name: "Bad",
+            channels: [
+              { offset: 0, name: "Red", type: "ColorIntensity", color: "Red", defaultValue: 0 },
+              { offset: 0, name: "Green", type: "ColorIntensity", color: "Green", defaultValue: 0 },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/duplicate.*offset/i);
+  });
+
+  it("rejects duplicate mode names within template", () => {
+    const result = validateUserFixtureTemplate(
+      makeRequest({
+        modes: [
+          {
+            name: "3ch",
+            channels: [{ offset: 0, name: "Dimmer", type: "Intensity", defaultValue: 0 }],
+          },
+          {
+            name: "3ch",
+            channels: [
+              { offset: 0, name: "Red", type: "ColorIntensity", color: "Red", defaultValue: 0 },
+              { offset: 1, name: "Green", type: "ColorIntensity", color: "Green", defaultValue: 0 },
+              { offset: 2, name: "Blue", type: "ColorIntensity", color: "Blue", defaultValue: 0 },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/duplicate.*mode/i);
+  });
+
+  it("delegates channel validation — rejects bad defaultValue", () => {
+    const result = validateUserFixtureTemplate(
+      makeRequest({
+        modes: [
+          {
+            name: "Bad",
+            channels: [
+              { offset: 0, name: "Red", type: "ColorIntensity", color: "Red", defaultValue: 300 },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/defaultValue/i);
+  });
+});

--- a/server/src/fixtures/user-fixture-validator.ts
+++ b/server/src/fixtures/user-fixture-validator.ts
@@ -1,0 +1,60 @@
+import type { ValidationResult } from "./fixture-validator.js";
+import { validateFixtureChannels } from "./fixture-validator.js";
+import type { CreateUserFixtureRequest, UpdateUserFixtureRequest } from "./user-fixture-types.js";
+
+export function validateUserFixtureTemplate(
+  request: CreateUserFixtureRequest | UpdateUserFixtureRequest,
+): ValidationResult {
+  const name = "name" in request ? request.name : undefined;
+  if (name !== undefined && name.trim().length === 0) {
+    return { valid: false, error: "Fixture name is required" };
+  }
+
+  const manufacturer = "manufacturer" in request ? request.manufacturer : undefined;
+  if (manufacturer !== undefined && manufacturer.trim().length === 0) {
+    return { valid: false, error: "Manufacturer is required" };
+  }
+
+  const modes = request.modes;
+  if (modes !== undefined) {
+    if (modes.length === 0) {
+      return { valid: false, error: "At least one mode is required" };
+    }
+
+    const modeNames = new Set<string>();
+    for (const mode of modes) {
+      if (mode.name.trim().length === 0) {
+        return { valid: false, error: "Mode name is required" };
+      }
+
+      if (modeNames.has(mode.name)) {
+        return { valid: false, error: `Duplicate mode name: "${mode.name}"` };
+      }
+      modeNames.add(mode.name);
+
+      if (mode.channels.length === 0) {
+        return { valid: false, error: `Mode "${mode.name}" must have at least one channel` };
+      }
+
+      // Check duplicate offsets
+      const offsets = new Set<number>();
+      for (const ch of mode.channels) {
+        if (offsets.has(ch.offset)) {
+          return {
+            valid: false,
+            error: `Duplicate channel offset ${ch.offset} in mode "${mode.name}"`,
+          };
+        }
+        offsets.add(ch.offset);
+      }
+
+      // Delegate to existing channel validator
+      const channelResult = validateFixtureChannels(mode.channels, mode.channels.length);
+      if (!channelResult.valid) {
+        return channelResult;
+      }
+    }
+  }
+
+  return { valid: true };
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,6 +6,7 @@ import { createSettingsStore } from "./config/settings-store.js";
 import { createUniverseManager } from "./dmx/universe-manager.js";
 import { createResilientConnection } from "./dmx/resilient-connection.js";
 import { createFixtureStore } from "./fixtures/fixture-store.js";
+import { createUserFixtureStore } from "./fixtures/user-fixture-store.js";
 import { autoDetectDmxPort } from "./dmx/serial-port-scanner.js";
 import {
   createMdnsAdvertiser,
@@ -14,6 +15,7 @@ import {
 import { createOflClient } from "./ofl/ofl-client.js";
 import { createSsClientIfConfigured } from "./soundswitch/ss-client.js";
 import { createLocalDbProvider } from "./libraries/local-db-provider.js";
+import { createUserFixtureProvider } from "./libraries/user-fixture-provider.js";
 import { createOflProvider } from "./libraries/ofl-provider.js";
 import { createLibraryRegistry } from "./libraries/registry.js";
 import { buildServer } from "./server.js";
@@ -107,6 +109,9 @@ async function main() {
   const fixtureStore = createFixtureStore(finalConfig.fixturesPath);
   await fixtureStore.load();
 
+  const userFixtureStore = createUserFixtureStore(finalConfig.userFixturesPath);
+  await userFixtureStore.load();
+
   pipeLog("info", `Loaded ${fixtureStore.getAll().length} fixtures, initializing defaults...`);
 
   // Register safe positions for motor channels (Pan/Tilt/Focus/Zoom etc.)
@@ -144,7 +149,8 @@ async function main() {
 
   const oflProvider = createOflProvider(oflClient);
   const localDbProvider = createLocalDbProvider(ssClient, ssStatus);
-  const registry = createLibraryRegistry([oflProvider, localDbProvider]);
+  const userFixtureProvider = createUserFixtureProvider(userFixtureStore);
+  const registry = createLibraryRegistry([oflProvider, localDbProvider, userFixtureProvider]);
 
   const udpServer = createUdpColorServer({
     fixtureStore,
@@ -161,6 +167,7 @@ async function main() {
     fixtureStore,
     oflClient,
     registry,
+    userFixtureStore,
     getConnectionStatus: () => connection.getStatus(),
     settingsStore,
     serverVersion,

--- a/server/src/libraries/user-fixture-provider.test.ts
+++ b/server/src/libraries/user-fixture-provider.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createUserFixtureProvider } from "./user-fixture-provider.js";
+import { createUserFixtureStore } from "../fixtures/user-fixture-store.js";
+import type { UserFixtureStore } from "../fixtures/user-fixture-store.js";
+import type { FixtureLibraryProvider } from "./types.js";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { rm } from "node:fs/promises";
+
+function addTestTemplate(
+  store: UserFixtureStore,
+  overrides: {
+    name?: string;
+    manufacturer?: string;
+    category?: string;
+    modes?: { name: string; channels: { offset: number; name: string; type: string; color?: string; defaultValue: number }[] }[];
+  } = {},
+) {
+  return store.add({
+    name: overrides.name ?? "Test PAR",
+    manufacturer: overrides.manufacturer ?? "DIY",
+    category: overrides.category ?? "Color Changer",
+    modes: overrides.modes ?? [
+      {
+        name: "3ch",
+        channels: [
+          { offset: 0, name: "Red", type: "ColorIntensity", color: "Red", defaultValue: 0 },
+          { offset: 1, name: "Green", type: "ColorIntensity", color: "Green", defaultValue: 0 },
+          { offset: 2, name: "Blue", type: "ColorIntensity", color: "Blue", defaultValue: 0 },
+        ],
+      },
+    ],
+  });
+}
+
+describe("createUserFixtureProvider", () => {
+  let store: UserFixtureStore;
+  let provider: FixtureLibraryProvider;
+  let filePath: string;
+
+  beforeEach(() => {
+    filePath = join(tmpdir(), `dmxr-ufp-test-${Date.now()}.json`);
+    store = createUserFixtureStore(filePath);
+    provider = createUserFixtureProvider(store);
+  });
+
+  afterEach(async () => {
+    store.dispose();
+    try {
+      await rm(filePath);
+    } catch {
+      // ignore
+    }
+  });
+
+  it('has id "custom" and displayName "My Fixtures"', () => {
+    expect(provider.id).toBe("custom");
+    expect(provider.displayName).toBe("My Fixtures");
+  });
+
+  it("status is always available", () => {
+    const status = provider.status();
+    expect(status.available).toBe(true);
+    expect(status.fixtureCount).toBe(0);
+  });
+
+  describe("getManufacturers", () => {
+    it("returns empty array when no templates", () => {
+      expect(provider.getManufacturers()).toEqual([]);
+    });
+
+    it("returns deduplicated manufacturers", () => {
+      addTestTemplate(store, { name: "PAR 1", manufacturer: "DIY" });
+      addTestTemplate(store, { name: "PAR 2", manufacturer: "DIY" });
+      addTestTemplate(store, { name: "Spot", manufacturer: "Acme" });
+
+      const mfrs = provider.getManufacturers();
+      expect(mfrs).toHaveLength(2);
+
+      const diy = mfrs.find((m) => m.name === "DIY");
+      expect(diy).toBeDefined();
+      expect(diy!.fixtureCount).toBe(2);
+
+      const acme = mfrs.find((m) => m.name === "Acme");
+      expect(acme).toBeDefined();
+      expect(acme!.fixtureCount).toBe(1);
+    });
+  });
+
+  describe("getFixtures", () => {
+    it("returns fixtures filtered by manufacturer", () => {
+      addTestTemplate(store, { name: "PAR 1", manufacturer: "DIY" });
+      addTestTemplate(store, { name: "Spot", manufacturer: "Acme" });
+
+      const mfrs = provider.getManufacturers();
+      const diyId = mfrs.find((m) => m.name === "DIY")!.id;
+
+      const fixtures = provider.getFixtures(diyId);
+      expect(fixtures).toHaveLength(1);
+      expect(fixtures[0].name).toBe("PAR 1");
+    });
+
+    it("returns empty for unknown manufacturer id", () => {
+      expect(provider.getFixtures(999)).toEqual([]);
+    });
+  });
+
+  describe("getFixtureModes", () => {
+    it("returns modes for a fixture", () => {
+      addTestTemplate(store, {
+        name: "Multi-Mode",
+        modes: [
+          { name: "3ch", channels: [{ offset: 0, name: "R", type: "ColorIntensity", color: "Red", defaultValue: 0 }] },
+          { name: "7ch", channels: [{ offset: 0, name: "R", type: "ColorIntensity", color: "Red", defaultValue: 0 }] },
+        ],
+      });
+
+      const mfrs = provider.getManufacturers();
+      const fixtures = provider.getFixtures(mfrs[0].id);
+      const modes = provider.getFixtureModes(fixtures[0].id);
+
+      expect(modes).toHaveLength(2);
+      expect(modes[0].name).toBe("3ch");
+      expect(modes[1].name).toBe("7ch");
+    });
+
+    it("returns empty for unknown fixture id", () => {
+      expect(provider.getFixtureModes(999)).toEqual([]);
+    });
+  });
+
+  describe("getModeChannels", () => {
+    it("returns channels for a mode", () => {
+      addTestTemplate(store);
+
+      const mfrs = provider.getManufacturers();
+      const fixtures = provider.getFixtures(mfrs[0].id);
+      const modes = provider.getFixtureModes(fixtures[0].id);
+      const channels = provider.getModeChannels(modes[0].id);
+
+      expect(channels).toHaveLength(3);
+      expect(channels[0].name).toBe("Red");
+      expect(channels[1].name).toBe("Green");
+      expect(channels[2].name).toBe("Blue");
+    });
+
+    it("returns empty for unknown mode id", () => {
+      expect(provider.getModeChannels(999)).toEqual([]);
+    });
+  });
+
+  describe("searchFixtures", () => {
+    it("matches by name", () => {
+      addTestTemplate(store, { name: "SuperBeam 5000" });
+
+      const results = provider.searchFixtures("superbeam");
+      expect(results).toHaveLength(1);
+      expect(results[0].fixtureName).toBe("SuperBeam 5000");
+    });
+
+    it("matches by manufacturer", () => {
+      addTestTemplate(store, { manufacturer: "Acme Lighting" });
+
+      const results = provider.searchFixtures("acme");
+      expect(results).toHaveLength(1);
+      expect(results[0].mfrName).toBe("Acme Lighting");
+    });
+
+    it("returns empty for no match", () => {
+      addTestTemplate(store);
+      expect(provider.searchFixtures("zzzzz")).toEqual([]);
+    });
+
+    it("returns empty for short tokens", () => {
+      addTestTemplate(store);
+      expect(provider.searchFixtures("a")).toEqual([]);
+    });
+
+    it("respects limit", () => {
+      addTestTemplate(store, { name: "PAR 1" });
+      addTestTemplate(store, { name: "PAR 2" });
+      addTestTemplate(store, { name: "PAR 3" });
+
+      const results = provider.searchFixtures("PAR", 2);
+      expect(results).toHaveLength(2);
+    });
+  });
+});

--- a/server/src/libraries/user-fixture-provider.ts
+++ b/server/src/libraries/user-fixture-provider.ts
@@ -1,0 +1,167 @@
+import type { UserFixtureStore } from "../fixtures/user-fixture-store.js";
+import type {
+  FixtureLibraryProvider,
+  LibraryStatus,
+  LibraryManufacturer,
+  LibraryFixture,
+  LibraryMode,
+  LibrarySearchResult,
+} from "./types.js";
+import type { FixtureChannel } from "../types/protocol.js";
+
+/**
+ * Library provider that exposes user-created fixture templates
+ * via the same interface as OFL/local-db providers.
+ *
+ * Uses incremental numeric IDs mapped to UUID strings since
+ * the FixtureLibraryProvider interface uses `number` IDs.
+ */
+export function createUserFixtureProvider(
+  store: UserFixtureStore,
+): FixtureLibraryProvider {
+  // Bidirectional maps: numeric ID ↔ UUID string
+  // Rebuilt on each accessor call to stay in sync with store changes.
+  function buildMaps() {
+    const templates = store.getAll();
+
+    const mfrNameToId = new Map<string, number>();
+    const mfrIdToName = new Map<number, string>();
+    const fixtureUuidToId = new Map<string, number>();
+    const fixtureIdToUuid = new Map<number, string>();
+    const modeUuidToId = new Map<string, number>();
+    const modeIdToUuid = new Map<number, string>();
+
+    let mfrCounter = 1;
+    let fixtureCounter = 1;
+    let modeCounter = 1;
+
+    for (const t of templates) {
+      // Manufacturer dedup
+      if (!mfrNameToId.has(t.manufacturer)) {
+        mfrNameToId.set(t.manufacturer, mfrCounter);
+        mfrIdToName.set(mfrCounter, t.manufacturer);
+        mfrCounter++;
+      }
+
+      // Fixture
+      fixtureUuidToId.set(t.id, fixtureCounter);
+      fixtureIdToUuid.set(fixtureCounter, t.id);
+      fixtureCounter++;
+
+      // Modes
+      for (const m of t.modes) {
+        modeUuidToId.set(m.id, modeCounter);
+        modeIdToUuid.set(modeCounter, m.id);
+        modeCounter++;
+      }
+    }
+
+    return {
+      templates,
+      mfrNameToId,
+      mfrIdToName,
+      fixtureUuidToId,
+      fixtureIdToUuid,
+      modeUuidToId,
+      modeIdToUuid,
+    };
+  }
+
+  return {
+    id: "custom",
+    displayName: "My Fixtures",
+    description: "User-created custom fixture templates",
+    type: "local-db",
+
+    status(): LibraryStatus {
+      return {
+        available: true,
+        state: "ready",
+        fixtureCount: store.getAll().length,
+      };
+    },
+
+    getManufacturers(): readonly LibraryManufacturer[] {
+      const { templates, mfrNameToId } = buildMaps();
+
+      // Count fixtures per manufacturer
+      const counts = new Map<string, number>();
+      for (const t of templates) {
+        counts.set(t.manufacturer, (counts.get(t.manufacturer) ?? 0) + 1);
+      }
+
+      const result: LibraryManufacturer[] = [];
+      for (const [name, id] of mfrNameToId) {
+        result.push({ id, name, fixtureCount: counts.get(name) ?? 0 });
+      }
+      return result;
+    },
+
+    getFixtures(manufacturerId: number): readonly LibraryFixture[] {
+      const { templates, mfrIdToName, fixtureUuidToId } = buildMaps();
+      const mfrName = mfrIdToName.get(manufacturerId);
+      if (!mfrName) return [];
+
+      return templates
+        .filter((t) => t.manufacturer === mfrName)
+        .map((t) => ({
+          id: fixtureUuidToId.get(t.id)!,
+          name: t.name,
+          modeCount: t.modes.length,
+        }));
+    },
+
+    getFixtureModes(fixtureId: number): readonly LibraryMode[] {
+      const { templates, fixtureIdToUuid, modeUuidToId } = buildMaps();
+      const uuid = fixtureIdToUuid.get(fixtureId);
+      if (!uuid) return [];
+
+      const template = templates.find((t) => t.id === uuid);
+      if (!template) return [];
+
+      return template.modes.map((m) => ({
+        id: modeUuidToId.get(m.id)!,
+        name: m.name,
+        channelCount: m.channels.length,
+      }));
+    },
+
+    getModeChannels(modeId: number): readonly FixtureChannel[] {
+      const { templates, modeIdToUuid } = buildMaps();
+      const uuid = modeIdToUuid.get(modeId);
+      if (!uuid) return [];
+
+      for (const t of templates) {
+        const mode = t.modes.find((m) => m.id === uuid);
+        if (mode) return mode.channels;
+      }
+      return [];
+    },
+
+    searchFixtures(query: string, limit?: number): readonly LibrarySearchResult[] {
+      const { templates, fixtureUuidToId, mfrNameToId } = buildMaps();
+      const tokens = query
+        .toLowerCase()
+        .split(/\s+/)
+        .filter((t) => t.length >= 2);
+      if (tokens.length === 0) return [];
+
+      const results: LibrarySearchResult[] = [];
+      for (const t of templates) {
+        const combined = `${t.name} ${t.manufacturer} ${t.category}`.toLowerCase();
+        if (tokens.every((tok) => combined.includes(tok))) {
+          results.push({
+            fixtureId: fixtureUuidToId.get(t.id)!,
+            fixtureName: t.name,
+            mfrId: mfrNameToId.get(t.manufacturer)!,
+            mfrName: t.manufacturer,
+            modeCount: t.modes.length,
+            category: t.category,
+          });
+        }
+        if (limit && results.length >= limit) break;
+      }
+      return results;
+    },
+  };
+}

--- a/server/src/routes/user-fixtures-integration.test.ts
+++ b/server/src/routes/user-fixtures-integration.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { buildServer } from "../server.js";
+import { createUniverseManager } from "../dmx/universe-manager.js";
+import {
+  createMockUniverse,
+  createTestConfig,
+  createTestFixtureStore,
+  createTestUserFixtureStore,
+  createMockOflClient,
+} from "../test-helpers.js";
+import { createUserFixtureProvider } from "../libraries/user-fixture-provider.js";
+import { createLibraryRegistry } from "../libraries/registry.js";
+import type { UserFixtureStore } from "../fixtures/user-fixture-store.js";
+import type { FixtureStore } from "../fixtures/fixture-store.js";
+import type { FastifyInstance } from "fastify";
+
+const templatePayload = {
+  name: "My RGB PAR",
+  manufacturer: "DIY",
+  category: "Color Changer",
+  modes: [
+    {
+      name: "3-channel",
+      channels: [
+        { offset: 0, name: "Red", type: "ColorIntensity", color: "Red", defaultValue: 0 },
+        { offset: 1, name: "Green", type: "ColorIntensity", color: "Green", defaultValue: 0 },
+        { offset: 2, name: "Blue", type: "ColorIntensity", color: "Blue", defaultValue: 0 },
+      ],
+    },
+  ],
+};
+
+describe("Custom fixture integration: create → browse → import", () => {
+  let app: FastifyInstance;
+  let userStore: UserFixtureStore;
+  let fixtureStore: FixtureStore;
+
+  beforeEach(async () => {
+    const universe = createMockUniverse();
+    const manager = createUniverseManager(universe);
+    manager.resumeNormal();
+
+    userStore = createTestUserFixtureStore();
+    fixtureStore = createTestFixtureStore();
+
+    const userProvider = createUserFixtureProvider(userStore);
+    const registry = createLibraryRegistry([
+      {
+        id: "ofl",
+        displayName: "Open Fixture Library",
+        description: "OFL",
+        type: "api",
+        status: () => ({ available: true, state: "connected" }),
+        getManufacturers: () => [],
+        getFixtures: () => [],
+        getFixtureModes: () => [],
+        getModeChannels: () => [],
+        searchFixtures: () => [],
+      },
+      userProvider,
+    ]);
+
+    app = await buildServer({
+      config: createTestConfig(),
+      manager,
+      driver: "null",
+      startTime: Date.now(),
+      fixtureStore,
+      oflClient: createMockOflClient(),
+      registry,
+      userFixtureStore: userStore,
+    });
+  });
+
+  afterEach(async () => {
+    userStore.dispose();
+    await app.close();
+  });
+
+  it("full flow: create template → browse library → import to fixtures", async () => {
+    // 1. Create template via API
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/user-fixtures",
+      payload: templatePayload,
+    });
+    expect(createRes.statusCode).toBe(201);
+    const template = createRes.json();
+    expect(template.id).toBeDefined();
+
+    // 2. Browse via library — see manufacturer
+    const mfrsRes = await app.inject({
+      method: "GET",
+      url: "/libraries/custom/manufacturers",
+    });
+    expect(mfrsRes.statusCode).toBe(200);
+    const mfrs = mfrsRes.json();
+    expect(mfrs).toHaveLength(1);
+    expect(mfrs[0].name).toBe("DIY");
+    const mfrId = mfrs[0].id;
+
+    // 3. Browse fixtures for manufacturer
+    const fixturesRes = await app.inject({
+      method: "GET",
+      url: `/libraries/custom/manufacturers/${mfrId}/fixtures`,
+    });
+    expect(fixturesRes.statusCode).toBe(200);
+    const fixtures = fixturesRes.json();
+    expect(fixtures).toHaveLength(1);
+    expect(fixtures[0].name).toBe("My RGB PAR");
+    const fixtureId = fixtures[0].id;
+
+    // 4. Get modes
+    const modesRes = await app.inject({
+      method: "GET",
+      url: `/libraries/custom/fixtures/${fixtureId}/modes`,
+    });
+    expect(modesRes.statusCode).toBe(200);
+    const modesData = modesRes.json();
+    expect(modesData.modes).toHaveLength(1);
+    expect(modesData.modes[0].name).toBe("3-channel");
+    expect(modesData.modes[0].channelCount).toBe(3);
+    const modeId = modesData.modes[0].id;
+
+    // 5. Get channels
+    const channelsRes = await app.inject({
+      method: "GET",
+      url: `/libraries/custom/fixtures/${fixtureId}/modes/${modeId}/channels`,
+    });
+    expect(channelsRes.statusCode).toBe(200);
+    const channels = channelsRes.json();
+    expect(channels).toHaveLength(3);
+    expect(channels[0].name).toBe("Red");
+
+    // 6. Import fixture via library import endpoint
+    const importRes = await app.inject({
+      method: "POST",
+      url: `/libraries/custom/fixtures/${fixtureId}/modes/${modeId}/import`,
+      payload: { name: "Stage Left PAR", dmxStartAddress: 1 },
+    });
+    expect(importRes.statusCode).toBe(201);
+    const imported = importRes.json();
+    expect(imported.name).toBe("Stage Left PAR");
+    expect(imported.source).toBe("custom");
+    expect(imported.channelCount).toBe(3);
+    expect(imported.channels).toHaveLength(3);
+
+    // 7. Verify in fixture store
+    const allFixtures = await app.inject({ method: "GET", url: "/fixtures" });
+    expect(allFixtures.json()).toHaveLength(1);
+    expect(allFixtures.json()[0].id).toBe(imported.id);
+    expect(allFixtures.json()[0].source).toBe("custom");
+  });
+
+  it("custom library shows in /libraries listing", async () => {
+    const res = await app.inject({ method: "GET", url: "/libraries" });
+    expect(res.statusCode).toBe(200);
+    const libs = res.json();
+    const custom = libs.find((l: { id: string }) => l.id === "custom");
+    expect(custom).toBeDefined();
+    expect(custom.displayName).toBe("My Fixtures");
+    expect(custom.status.available).toBe(true);
+  });
+});

--- a/server/src/routes/user-fixtures.test.ts
+++ b/server/src/routes/user-fixtures.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { buildServer } from "../server.js";
+import { createUniverseManager } from "../dmx/universe-manager.js";
+import {
+  createMockUniverse,
+  createTestConfig,
+  createTestFixtureStore,
+  createTestUserFixtureStore,
+  createMockOflClient,
+  createMockRegistry,
+} from "../test-helpers.js";
+import type { UserFixtureStore } from "../fixtures/user-fixture-store.js";
+import type { FastifyInstance } from "fastify";
+
+const validTemplateBody = {
+  name: "My Custom PAR",
+  manufacturer: "DIY",
+  category: "Color Changer",
+  modes: [
+    {
+      name: "3-channel",
+      channels: [
+        { offset: 0, name: "Red", type: "ColorIntensity", color: "Red", defaultValue: 0 },
+        { offset: 1, name: "Green", type: "ColorIntensity", color: "Green", defaultValue: 0 },
+        { offset: 2, name: "Blue", type: "ColorIntensity", color: "Blue", defaultValue: 0 },
+      ],
+    },
+  ],
+};
+
+describe("User fixture routes", () => {
+  let app: FastifyInstance;
+  let userStore: UserFixtureStore;
+
+  beforeEach(async () => {
+    const universe = createMockUniverse();
+    const manager = createUniverseManager(universe);
+    manager.resumeNormal();
+    userStore = createTestUserFixtureStore();
+
+    app = await buildServer({
+      config: createTestConfig(),
+      manager,
+      driver: "null",
+      startTime: Date.now(),
+      fixtureStore: createTestFixtureStore(),
+      oflClient: createMockOflClient(),
+      registry: createMockRegistry(),
+      userFixtureStore: userStore,
+    });
+  });
+
+  afterEach(async () => {
+    userStore.dispose();
+    await app.close();
+  });
+
+  describe("GET /user-fixtures", () => {
+    it("returns empty array initially", async () => {
+      const res = await app.inject({ method: "GET", url: "/user-fixtures" });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual([]);
+    });
+
+    it("returns templates after adding", async () => {
+      userStore.add(validTemplateBody);
+
+      const res = await app.inject({ method: "GET", url: "/user-fixtures" });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toHaveLength(1);
+      expect(res.json()[0].name).toBe("My Custom PAR");
+    });
+  });
+
+  describe("POST /user-fixtures", () => {
+    it("creates template and returns 201 with UUID", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/user-fixtures",
+        payload: validTemplateBody,
+      });
+
+      expect(res.statusCode).toBe(201);
+      const body = res.json();
+      expect(body.id).toBeDefined();
+      expect(body.name).toBe("My Custom PAR");
+      expect(body.manufacturer).toBe("DIY");
+      expect(body.modes).toHaveLength(1);
+      expect(body.modes[0].id).toBeDefined();
+      expect(body.createdAt).toBeDefined();
+    });
+
+    it("returns 400 for missing name", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/user-fixtures",
+        payload: { ...validTemplateBody, name: "" },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("returns 400 for missing manufacturer", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/user-fixtures",
+        payload: { ...validTemplateBody, manufacturer: "" },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("returns 400 for empty modes array", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/user-fixtures",
+        payload: { ...validTemplateBody, modes: [] },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("returns 400 for duplicate channel offsets", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/user-fixtures",
+        payload: {
+          ...validTemplateBody,
+          modes: [
+            {
+              name: "bad",
+              channels: [
+                { offset: 0, name: "Red", type: "ColorIntensity", color: "Red", defaultValue: 0 },
+                { offset: 0, name: "Green", type: "ColorIntensity", color: "Green", defaultValue: 0 },
+              ],
+            },
+          ],
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/duplicate.*offset/i);
+    });
+
+    it("returns 400 for duplicate mode names", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/user-fixtures",
+        payload: {
+          ...validTemplateBody,
+          modes: [
+            {
+              name: "same",
+              channels: [{ offset: 0, name: "Dimmer", type: "Intensity", defaultValue: 0 }],
+            },
+            {
+              name: "same",
+              channels: [{ offset: 0, name: "Red", type: "ColorIntensity", color: "Red", defaultValue: 0 }],
+            },
+          ],
+        },
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/duplicate.*mode/i);
+    });
+  });
+
+  describe("GET /user-fixtures/:id", () => {
+    it("returns template by id", async () => {
+      const template = userStore.add(validTemplateBody);
+
+      const res = await app.inject({
+        method: "GET",
+        url: `/user-fixtures/${template.id}`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().name).toBe("My Custom PAR");
+    });
+
+    it("returns 404 for unknown id", async () => {
+      const res = await app.inject({
+        method: "GET",
+        url: "/user-fixtures/nonexistent",
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe("PATCH /user-fixtures/:id", () => {
+    it("updates template and returns 200", async () => {
+      const template = userStore.add(validTemplateBody);
+
+      const res = await app.inject({
+        method: "PATCH",
+        url: `/user-fixtures/${template.id}`,
+        payload: { name: "Updated PAR" },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().name).toBe("Updated PAR");
+      expect(res.json().manufacturer).toBe("DIY");
+    });
+
+    it("returns 404 for unknown id", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/user-fixtures/nonexistent",
+        payload: { name: "X" },
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe("DELETE /user-fixtures/:id", () => {
+    it("removes template and returns success", async () => {
+      const template = userStore.add(validTemplateBody);
+
+      const res = await app.inject({
+        method: "DELETE",
+        url: `/user-fixtures/${template.id}`,
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.json().success).toBe(true);
+      expect(userStore.getAll()).toHaveLength(0);
+    });
+
+    it("returns 404 for unknown id", async () => {
+      const res = await app.inject({
+        method: "DELETE",
+        url: "/user-fixtures/nonexistent",
+      });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+});

--- a/server/src/routes/user-fixtures.ts
+++ b/server/src/routes/user-fixtures.ts
@@ -1,0 +1,136 @@
+import type { FastifyInstance } from "fastify";
+import type { UserFixtureStore } from "../fixtures/user-fixture-store.js";
+import type { CreateUserFixtureRequest, UpdateUserFixtureRequest } from "../fixtures/user-fixture-types.js";
+import { validateUserFixtureTemplate } from "../fixtures/user-fixture-validator.js";
+
+interface UserFixtureRouteDeps {
+  readonly store: UserFixtureStore;
+}
+
+const channelSchema = {
+  type: "object" as const,
+  required: ["offset", "name", "type", "defaultValue"],
+  properties: {
+    offset: { type: "integer" as const, minimum: 0 },
+    name: { type: "string" as const },
+    type: { type: "string" as const },
+    color: { type: "string" as const },
+    defaultValue: { type: "integer" as const, minimum: 0, maximum: 255 },
+    rangeMin: { type: "integer" as const, minimum: 0, maximum: 255 },
+    rangeMax: { type: "integer" as const, minimum: 0, maximum: 255 },
+  },
+};
+
+const modeSchema = {
+  type: "object" as const,
+  required: ["name", "channels"],
+  properties: {
+    name: { type: "string" as const, minLength: 1 },
+    channels: {
+      type: "array" as const,
+      items: channelSchema,
+      minItems: 1,
+    },
+  },
+};
+
+const createSchema = {
+  body: {
+    type: "object" as const,
+    required: ["name", "manufacturer", "category", "modes"],
+    properties: {
+      name: { type: "string" as const, minLength: 1 },
+      manufacturer: { type: "string" as const, minLength: 1 },
+      category: { type: "string" as const },
+      modes: {
+        type: "array" as const,
+        items: modeSchema,
+        minItems: 1,
+      },
+    },
+  },
+};
+
+const updateSchema = {
+  body: {
+    type: "object" as const,
+    properties: {
+      name: { type: "string" as const, minLength: 1 },
+      manufacturer: { type: "string" as const, minLength: 1 },
+      category: { type: "string" as const },
+      modes: {
+        type: "array" as const,
+        items: modeSchema,
+        minItems: 1,
+      },
+    },
+  },
+};
+
+export function registerUserFixtureRoutes(
+  app: FastifyInstance,
+  deps: UserFixtureRouteDeps,
+): void {
+  app.get("/user-fixtures", async () => {
+    return deps.store.getAll();
+  });
+
+  app.post<{ Body: CreateUserFixtureRequest }>(
+    "/user-fixtures",
+    { schema: createSchema },
+    async (request, reply) => {
+      const validation = validateUserFixtureTemplate(request.body);
+      if (!validation.valid) {
+        return reply.status(400).send({ success: false, error: validation.error });
+      }
+
+      const template = deps.store.add(request.body);
+      await deps.store.save();
+      return reply.status(201).send(template);
+    },
+  );
+
+  app.get<{ Params: { id: string } }>(
+    "/user-fixtures/:id",
+    async (request, reply) => {
+      const template = deps.store.getById(request.params.id);
+      if (!template) {
+        return reply.status(404).send({ success: false, error: "Template not found" });
+      }
+      return template;
+    },
+  );
+
+  app.patch<{ Params: { id: string }; Body: UpdateUserFixtureRequest }>(
+    "/user-fixtures/:id",
+    { schema: updateSchema },
+    async (request, reply) => {
+      const existing = deps.store.getById(request.params.id);
+      if (!existing) {
+        return reply.status(404).send({ success: false, error: "Template not found" });
+      }
+
+      const validation = validateUserFixtureTemplate(request.body);
+      if (!validation.valid) {
+        return reply.status(400).send({ success: false, error: validation.error });
+      }
+
+      const updated = deps.store.update(request.params.id, request.body);
+      deps.store.scheduleSave();
+      return reply.status(200).send(updated);
+    },
+  );
+
+  app.delete<{ Params: { id: string } }>(
+    "/user-fixtures/:id",
+    async (request, reply) => {
+      const removed = deps.store.remove(request.params.id);
+      if (!removed) {
+        return reply.status(404).send({ success: false, error: "Template not found" });
+      }
+
+      await deps.store.save();
+      return { success: true };
+    },
+  );
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -8,6 +8,7 @@ import helmet from "@fastify/helmet";
 import type { ServerConfig } from "./config/server-config.js";
 import type { UniverseManager } from "./dmx/universe-manager.js";
 import type { FixtureStore } from "./fixtures/fixture-store.js";
+import type { UserFixtureStore } from "./fixtures/user-fixture-store.js";
 import type { OflClient } from "./ofl/ofl-client.js";
 import type { LibraryRegistry } from "./libraries/types.js";
 import type { ConnectionStatus } from "./dmx/connection-state.js";
@@ -22,6 +23,7 @@ import { registerSignalRgbRoutes } from "./routes/signalrgb.js";
 import { registerSearchRoutes } from "./routes/search.js";
 import { registerSettingsRoutes } from "./routes/settings.js";
 import { registerMetricsRoute } from "./routes/metrics.js";
+import { registerUserFixtureRoutes } from "./routes/user-fixtures.js";
 import { registerApiKeyAuth } from "./middleware/api-key-auth.js";
 import type { LatencyTracker } from "./metrics/latency-tracker.js";
 import type { MdnsAdvertiser } from "./mdns/advertiser.js";
@@ -35,6 +37,7 @@ interface BuildServerDeps {
   readonly driver: string;
   readonly startTime: number;
   readonly fixtureStore: FixtureStore;
+  readonly userFixtureStore?: UserFixtureStore;
   readonly oflClient: OflClient;
   readonly registry: LibraryRegistry;
   readonly getConnectionStatus?: () => ConnectionStatus;
@@ -142,6 +145,12 @@ export async function buildServer(
   registerSignalRgbRoutes(app, {
     store: deps.fixtureStore,
   });
+
+  if (deps.userFixtureStore) {
+    registerUserFixtureRoutes(app, {
+      store: deps.userFixtureStore,
+    });
+  }
 
   registerSearchRoutes(app, {
     oflClient: deps.oflClient,

--- a/server/src/test-helpers.ts
+++ b/server/src/test-helpers.ts
@@ -4,6 +4,8 @@ import type { ServerConfig } from "./config/server-config.js";
 import type { OflClient, OflSearchResult } from "./ofl/ofl-client.js";
 import { createFixtureStore } from "./fixtures/fixture-store.js";
 import type { FixtureStore } from "./fixtures/fixture-store.js";
+import { createUserFixtureStore } from "./fixtures/user-fixture-store.js";
+import type { UserFixtureStore } from "./fixtures/user-fixture-store.js";
 import type { LibraryRegistry } from "./libraries/types.js";
 import { createLibraryRegistry } from "./libraries/registry.js";
 
@@ -39,6 +41,7 @@ export function createTestConfig(overrides: Partial<ServerConfig> = {}): ServerC
     dmxDevicePath: "",
     logLevel: "silent",
     fixturesPath: uniqueFixturesPath(),
+    userFixturesPath: `/tmp/dmxr-test-user-fixtures-${randomUUID()}.json`,
     mdnsEnabled: false,
     portRangeSize: 10,
     ...overrides,
@@ -47,6 +50,10 @@ export function createTestConfig(overrides: Partial<ServerConfig> = {}): ServerC
 
 export function createTestFixtureStore(): FixtureStore {
   return createFixtureStore(uniqueFixturesPath());
+}
+
+export function createTestUserFixtureStore(): UserFixtureStore {
+  return createUserFixtureStore(`/tmp/dmxr-test-user-fixtures-${randomUUID()}.json`);
 }
 
 export function createMockOflClient(): OflClient {


### PR DESCRIPTION
## Summary
- Adds a full custom fixture template system: users can create, edit, and reuse fixture definitions from the web UI
- Templates are persisted in `config/user-fixtures.json` and browsable via the library browser as a "Custom" source
- Integrates with the existing browse → stage → drag-to-grid pipeline — no new concepts for users

## What's new

### Backend
- **User fixture template store** (`user-fixture-store.ts`) — CRUD with atomic writes, debounced save, follows `fixture-store` pattern
- **Template validator** (`user-fixture-validator.ts`) — validates name, manufacturer, modes, channels, duplicate offsets/mode names; delegates channel validation to existing `validateFixtureChannels()`
- **CRUD API routes** — `GET/POST/PATCH/DELETE /user-fixtures` with Fastify JSON schema validation
- **Library provider** (`user-fixture-provider.ts`) — implements `FixtureLibraryProvider` interface with numeric ID mapping, so custom fixtures are browsable/searchable/importable through existing `/libraries/custom/*` routes
- **Server config** — new `userFixturesPath` field (default `./config/user-fixtures.json`)

### Frontend
- **"Custom" tab** in Browse panel source selector
- **Template list** with edit/delete/click-to-stage
- **3-step channel builder**: Info (name, manufacturer, category) → Channels (add/remove/reorder rows with type/color dropdowns) → Review → Save & Stage
- Auto-stages fixture for grid placement after save

## Test plan
- [x] 75 new tests across 6 test files (565 total, 0 failures)
- [x] `npx tsc --noEmit` — clean
- [x] Integration test: create template → browse via library → import → verify in fixtures
- [x] Manual: open web UI → Browse → Custom → create fixture → stage → drag to grid → verify DMX output
- [x] Manual: reload page → saved template appears in Custom tab
- [x] Manual: edit existing template, delete template

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)