### PR TITLE
feat: ArtNet and sACN network DMX output

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -957,20 +957,51 @@
           <option value="null">None (test mode)</option>
           <option value="enttec-usb-dmx-pro">ENTTEC USB DMX Pro</option>
           <option value="enttec-open-usb-dmx">Open DMX USB (FTDI-based adapters)</option>
+          <option value="artnet">Art-Net (network)</option>
+          <option value="sacn">sACN / E1.31 (network)</option>
         </select>
 
-        <label>COM Port</label>
-        <div class="port-row">
-          <select x-model="settingsDevicePath">
-            <option value="auto">Auto-detect</option>
-            <template x-for="port in availablePorts" :key="port.path">
-              <option :value="port.path" x-text="getPortLabel(port)"></option>
-            </template>
-          </select>
-          <button class="btn btn-sm" @click="scanPorts()" :disabled="portsScanning">
-            <span x-text="portsScanning ? 'Scanning...' : 'Scan'"></span>
-          </button>
-        </div>
+        <!-- Serial driver: COM port selection -->
+        <template x-if="isSerialDriver(settingsDriver)">
+          <div>
+            <label>COM Port</label>
+            <div class="port-row">
+              <select x-model="settingsDevicePath">
+                <option value="auto">Auto-detect</option>
+                <template x-for="port in availablePorts" :key="port.path">
+                  <option :value="port.path" x-text="getPortLabel(port)"></option>
+                </template>
+              </select>
+              <button class="btn btn-sm" @click="scanPorts()" :disabled="portsScanning">
+                <span x-text="portsScanning ? 'Scanning...' : 'Scan'"></span>
+              </button>
+            </div>
+          </div>
+        </template>
+
+        <!-- ArtNet: target IP + universe -->
+        <template x-if="settingsDriver === 'artnet'">
+          <div>
+            <label>Target IP</label>
+            <input type="text" x-model="settingsDevicePath" placeholder="255.255.255.255 (broadcast)">
+            <label>Art-Net Universe</label>
+            <input type="number" x-model.number="settingsDriverUniverse" min="0" max="32767">
+            <label>Art-Net Port <span class="settings-hint">(0–3, protocol port number)</span></label>
+            <input type="number" x-model.number="settingsDriverPort" min="0" max="3">
+          </div>
+        </template>
+
+        <!-- sACN: universe + priority + source name -->
+        <template x-if="settingsDriver === 'sacn'">
+          <div>
+            <label>sACN Universe</label>
+            <input type="number" x-model.number="settingsDriverUniverse" min="1" max="63999">
+            <label>Priority <span class="settings-hint">(0–200, default 100)</span></label>
+            <input type="number" x-model.number="settingsDriverPriority" min="0" max="200">
+            <label>Source Name</label>
+            <input type="text" x-model="settingsDriverSourceName" placeholder="DMXr">
+          </div>
+        </template>
 
         <label>HTTP Port</label>
         <input type="number" x-model.number="settingsPort" min="1024" max="65535">
@@ -1302,24 +1333,47 @@
           <option value="null">None (test mode — no DMX output)</option>
           <option value="enttec-usb-dmx-pro">ENTTEC USB DMX Pro</option>
           <option value="enttec-open-usb-dmx">Open DMX USB (FTDI-based adapters)</option>
+          <option value="artnet">Art-Net (network)</option>
+          <option value="sacn">sACN / E1.31 (network)</option>
         </select>
 
-        <label>COM Port</label>
-        <div class="port-row">
-          <select x-model="wizardDevicePath">
-            <option value="auto">Auto-detect</option>
-            <template x-for="port in wizardPorts" :key="port.path">
-              <option :value="port.path" x-text="getWizardPortLabel(port)"></option>
-            </template>
-          </select>
-          <button class="btn btn-sm" @click="wizardScanPorts()" :disabled="wizardScanning">
-            <span x-text="wizardScanning ? 'Scanning...' : 'Scan Ports'"></span>
-          </button>
-        </div>
+        <!-- Serial driver: COM port -->
+        <template x-if="isSerialDriver(wizardDriver)">
+          <div>
+            <label>COM Port</label>
+            <div class="port-row">
+              <select x-model="wizardDevicePath">
+                <option value="auto">Auto-detect</option>
+                <template x-for="port in wizardPorts" :key="port.path">
+                  <option :value="port.path" x-text="getWizardPortLabel(port)"></option>
+                </template>
+              </select>
+              <button class="btn btn-sm" @click="wizardScanPorts()" :disabled="wizardScanning">
+                <span x-text="wizardScanning ? 'Scanning...' : 'Scan Ports'"></span>
+              </button>
+            </div>
+            <div class="wizard-hint" x-show="wizardPorts.length === 0">
+              No serial ports detected. If your adapter is plugged in, click "Scan Ports".
+            </div>
+          </div>
+        </template>
 
-        <div class="wizard-hint" x-show="wizardPorts.length === 0">
-          No serial ports detected. If your adapter is plugged in, click "Scan Ports".
-        </div>
+        <!-- ArtNet: target IP -->
+        <template x-if="wizardDriver === 'artnet'">
+          <div>
+            <label>Target IP</label>
+            <input type="text" x-model="wizardDevicePath" placeholder="255.255.255.255 (broadcast)">
+          </div>
+        </template>
+
+        <!-- sACN: no extra config needed for wizard -->
+        <template x-if="wizardDriver === 'sacn'">
+          <div>
+            <div class="wizard-hint">
+              sACN uses multicast — no target address needed. Configure universe and priority in Settings after setup.
+            </div>
+          </div>
+        </template>
 
         <p class="validation-error" x-show="wizardError" x-text="wizardError"></p>
 
@@ -1335,7 +1389,7 @@
         <div class="wizard-summary">
           <div class="summary-row">
             <span class="summary-label">DMX Driver:</span>
-            <span x-text="wizardDriver === 'null' ? 'None (test mode)' : 'ENTTEC USB DMX Pro'"></span>
+            <span x-text="({null: 'None (test mode)', 'enttec-usb-dmx-pro': 'ENTTEC USB DMX Pro', 'enttec-open-usb-dmx': 'Open DMX USB', artnet: 'Art-Net', sacn: 'sACN / E1.31'})[wizardDriver] || wizardDriver"></span>
           </div>
           <div class="summary-row">
             <span class="summary-label">COM Port:</span>

--- a/server/public/js/settings.js
+++ b/server/public/js/settings.js
@@ -15,6 +15,12 @@ function dmxrSettings() {
     settingsMdns: true,
     settingsSetupCompleted: false,
 
+    // Network driver options (ArtNet / sACN)
+    settingsDriverUniverse: 0,
+    settingsDriverPort: 0,
+    settingsDriverSourceName: "DMXr",
+    settingsDriverPriority: 100,
+
     // Available ports
     availablePorts: [],
     portsScanning: false,
@@ -47,6 +53,11 @@ function dmxrSettings() {
         this.settingsHost = s.host;
         this.settingsMdns = s.mdnsEnabled;
         this.settingsSetupCompleted = s.setupCompleted;
+        var opts = s.driverOptions || {};
+        this.settingsDriverUniverse = opts.universe ?? 0;
+        this.settingsDriverPort = opts.port ?? 0;
+        this.settingsDriverSourceName = opts.sourceName || "DMXr";
+        this.settingsDriverPriority = opts.priority ?? 100;
         this.availablePorts = data.availablePorts || [];
         this.serverVersion = data.serverVersion || "";
         this.requiresRestart = false;
@@ -72,6 +83,12 @@ function dmxrSettings() {
             udpPort: this.settingsUdpPort,
             host: this.settingsHost,
             mdnsEnabled: this.settingsMdns,
+            driverOptions: this.isNetworkDriver(this.settingsDriver) ? {
+              universe: this.settingsDriverUniverse,
+              port: this.settingsDriverPort,
+              sourceName: this.settingsDriverSourceName,
+              priority: this.settingsDriverPriority,
+            } : undefined,
           }),
         });
         if (!res.ok) {
@@ -159,6 +176,14 @@ function dmxrSettings() {
 
     closeSettings() {
       this.showSettings = false;
+    },
+
+    isNetworkDriver(driver) {
+      return driver === "artnet" || driver === "sacn";
+    },
+
+    isSerialDriver(driver) {
+      return driver === "enttec-usb-dmx-pro" || driver === "enttec-open-usb-dmx";
     },
 
     getPortLabel(port) {

--- a/server/scripts/artnet-listener.ts
+++ b/server/scripts/artnet-listener.ts
@@ -1,0 +1,34 @@
+/**
+ * Standalone ArtNet listener for debugging DMXr output.
+ *
+ * Usage: npx tsx server/scripts/artnet-listener.ts [port] [universe]
+ *
+ * Listens for ArtNet packets and prints active (non-zero) channels.
+ * Default: port 6454, universe 0.
+ */
+import dmxnet from "dmxnet";
+
+const listenPort = parseInt(process.argv[2] ?? "6454", 10);
+const universe = parseInt(process.argv[3] ?? "0", 10);
+
+const net = new dmxnet.dmxnet({
+  listen: listenPort,
+  log: { level: "warn" },
+});
+
+const rx = net.newReceiver({ subnet: 0, universe, net: 0 });
+
+rx.on("data", (data: Buffer) => {
+  const active: Record<number, number> = {};
+  for (let i = 0; i < data.length; i++) {
+    if (data[i] > 0) {
+      active[i + 1] = data[i];
+    }
+  }
+  if (Object.keys(active).length > 0) {
+    console.log("DMX:", active);
+  }
+});
+
+console.log(`Listening for ArtNet on port ${listenPort}, universe ${universe}...`);
+console.log("Press Ctrl+C to stop.\n");

--- a/server/src/bootstrap/multi-universe-setup.ts
+++ b/server/src/bootstrap/multi-universe-setup.ts
@@ -36,6 +36,7 @@ export async function createMultiUniverseStack(
         ...config,
         dmxDriver: uniConfig.driverType,
         dmxDevicePath: uniConfig.devicePath,
+        driverOptions: uniConfig.driverOptions,
       };
       return createResilientConnection({
         config: uniServerConfig,

--- a/server/src/config/server-config.test.ts
+++ b/server/src/config/server-config.test.ts
@@ -141,4 +141,40 @@ describe("loadConfig", () => {
 
     expect(() => loadConfig()).toThrow("Invalid DMX_DRIVER");
   });
+
+  it("accepts artnet as a valid driver", () => {
+    process.env["DMX_DRIVER"] = "artnet";
+
+    const config = loadConfig();
+
+    expect(config.dmxDriver).toBe("artnet");
+  });
+
+  it("accepts sacn as a valid driver", () => {
+    process.env["DMX_DRIVER"] = "sacn";
+
+    const config = loadConfig();
+
+    expect(config.dmxDriver).toBe("sacn");
+  });
+
+  it("includes driverOptions from persisted settings", () => {
+    delete process.env["DMX_DRIVER"];
+
+    const config = loadConfig({
+      dmxDriver: "artnet",
+      dmxDevicePath: "192.168.1.100",
+      driverOptions: { universe: 2, port: 1 },
+    });
+
+    expect(config.driverOptions).toEqual({ universe: 2, port: 1 });
+  });
+
+  it("driverOptions is undefined when not provided", () => {
+    delete process.env["DMX_DRIVER"];
+
+    const config = loadConfig({ dmxDriver: "null" });
+
+    expect(config.driverOptions).toBeUndefined();
+  });
 });

--- a/server/src/config/server-config.ts
+++ b/server/src/config/server-config.ts
@@ -16,9 +16,21 @@ export interface ServerConfig {
   readonly userFixturesPath: string;
   readonly corsOrigin?: string;
   readonly apiKey?: string;
+  readonly driverOptions?: {
+    readonly universe?: number;
+    readonly port?: number;
+    readonly sourceName?: string;
+    readonly priority?: number;
+  };
 }
 
-const VALID_DRIVERS = ["null", "enttec-usb-dmx-pro", "enttec-open-usb-dmx"];
+const VALID_DRIVERS = [
+  "null",
+  "enttec-usb-dmx-pro",
+  "enttec-open-usb-dmx",
+  "artnet",
+  "sacn",
+];
 
 export function loadConfig(
   persisted?: Partial<PersistedSettings>,
@@ -84,6 +96,7 @@ export function loadConfig(
     localDbPath: resolveLocalDbPath(),
     corsOrigin: process.env["CORS_ORIGIN"] || undefined,
     apiKey: process.env["API_KEY"] || undefined,
+    driverOptions: base.driverOptions,
   };
 }
 

--- a/server/src/config/settings-store.ts
+++ b/server/src/config/settings-store.ts
@@ -13,6 +13,12 @@ export interface PersistedSettings {
   readonly serverId: string;
   readonly serverName: string;
   readonly onboardingCompleted: boolean;
+  readonly driverOptions?: {
+    readonly universe?: number;
+    readonly port?: number;
+    readonly sourceName?: string;
+    readonly priority?: number;
+  };
 }
 
 const DEFAULTS: PersistedSettings = {
@@ -50,6 +56,7 @@ function isValidSettings(data: unknown): data is Partial<PersistedSettings> {
   if ("serverId" in record && typeof record["serverId"] !== "string") return false;
   if ("serverName" in record && typeof record["serverName"] !== "string") return false;
   if ("onboardingCompleted" in record && typeof record["onboardingCompleted"] !== "boolean") return false;
+  if ("driverOptions" in record && record["driverOptions"] !== undefined && typeof record["driverOptions"] !== "object") return false;
 
   return true;
 }

--- a/server/src/dmx/driver-factory.test.ts
+++ b/server/src/dmx/driver-factory.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { createDmxConnection } from "./driver-factory.js";
+import type { ServerConfig } from "../config/server-config.js";
+
+const baseConfig: ServerConfig = {
+  port: 8080,
+  udpPort: 0,
+  host: "0.0.0.0",
+  dmxDriver: "null",
+  dmxDevicePath: "auto",
+  logLevel: "info",
+  logFormat: "pretty",
+  fixturesPath: "./config/fixtures.json",
+  mdnsEnabled: false,
+  portRangeSize: 10,
+  userFixturesPath: "./config/user-fixtures.json",
+};
+
+describe("createDmxConnection", () => {
+  it("creates a null driver connection", async () => {
+    const conn = await createDmxConnection(baseConfig);
+
+    expect(conn.driver).toBe("null");
+    expect(conn.universe).toBeDefined();
+    expect(conn.close).toBeDefined();
+    expect(conn.onDisconnect).toBeUndefined();
+
+    await conn.close();
+  });
+
+  it("throws on unknown driver", async () => {
+    await expect(
+      createDmxConnection({ ...baseConfig, dmxDriver: "fake-driver" }),
+    ).rejects.toThrow('Unknown DMX driver: "fake-driver"');
+  });
+
+  it("returns artnet driver string for artnet config", async () => {
+    const conn = await createDmxConnection({
+      ...baseConfig,
+      dmxDriver: "artnet",
+      dmxDevicePath: "127.0.0.1",
+      driverOptions: { universe: 0, port: 0 },
+    });
+
+    expect(conn.driver).toBe("artnet");
+    expect(conn.onDisconnect).toBeUndefined();
+
+    await conn.close();
+  });
+
+  it("returns sacn driver string for sacn config", async () => {
+    const conn = await createDmxConnection({
+      ...baseConfig,
+      dmxDriver: "sacn",
+      driverOptions: { universe: 1, sourceName: "Test", priority: 100 },
+    });
+
+    expect(conn.driver).toBe("sacn");
+    expect(conn.onDisconnect).toBeUndefined();
+
+    await conn.close();
+  });
+
+  it("artnet defaults to broadcast address when devicePath is empty", async () => {
+    const conn = await createDmxConnection({
+      ...baseConfig,
+      dmxDriver: "artnet",
+      dmxDevicePath: "",
+    });
+
+    expect(conn.driver).toBe("artnet");
+
+    await conn.close();
+  });
+
+  it("sacn defaults universe to 1 when no driverOptions", async () => {
+    const conn = await createDmxConnection({
+      ...baseConfig,
+      dmxDriver: "sacn",
+    });
+
+    expect(conn.driver).toBe("sacn");
+
+    await conn.close();
+  });
+});

--- a/server/src/dmx/driver-factory.ts
+++ b/server/src/dmx/driver-factory.ts
@@ -141,6 +141,80 @@ export async function createDmxConnection(
     };
   }
 
+  // ArtNet — UDP unicast/broadcast, connectionless.
+  // No onDisconnect: UDP is fire-and-forget. If the network path fails,
+  // packets simply don't arrive; when it recovers, the next update() resumes.
+  if (config.dmxDriver === "artnet") {
+    const { ArtnetDriver } = (await import(
+      "dmx-ts/dist/src/drivers/artnet.js"
+    )) as unknown as {
+      ArtnetDriver: new (
+        host: string,
+        options?: {
+          universe?: number;
+          port?: number;
+          net?: number;
+          subnet?: number;
+          subuni?: number;
+        },
+      ) => unknown;
+    };
+    const driver = new ArtnetDriver(
+      config.dmxDevicePath || "255.255.255.255",
+      {
+        universe: config.driverOptions?.universe ?? 0,
+        port: config.driverOptions?.port ?? 0,
+      },
+    );
+    // DMX.addUniverse calls driver.init() which creates the dmxnet sender
+    await dmx.addUniverse(UNIVERSE_NAME, driver);
+
+    return {
+      universe: {
+        update: (channels) => dmx.update(UNIVERSE_NAME, channels),
+        updateAll: (value) => dmx.updateAll(UNIVERSE_NAME, value),
+      },
+      driver: "artnet",
+      close: () => dmx.close(),
+    };
+  }
+
+  // sACN (E1.31) — multicast UDP, connectionless.
+  // SACNDriver converts 0–255 → 0–100% internally — transparent to callers.
+  if (config.dmxDriver === "sacn") {
+    const { SACNDriver } = (await import(
+      "dmx-ts/dist/src/drivers/sacn.js"
+    )) as unknown as {
+      SACNDriver: new (
+        universe: number,
+        options?: {
+          sourceName?: string;
+          priority?: number;
+          reuseAddr?: boolean;
+          ip?: string;
+        },
+      ) => unknown;
+    };
+    const driver = new SACNDriver(
+      config.driverOptions?.universe ?? 1,
+      {
+        sourceName: config.driverOptions?.sourceName ?? "DMXr",
+        priority: config.driverOptions?.priority ?? 100,
+      },
+    );
+    // SACNDriver.init() is a no-op — sender created in constructor
+    await dmx.addUniverse(UNIVERSE_NAME, driver);
+
+    return {
+      universe: {
+        update: (channels) => dmx.update(UNIVERSE_NAME, channels),
+        updateAll: (value) => dmx.updateAll(UNIVERSE_NAME, value),
+      },
+      driver: "sacn",
+      close: () => dmx.close(),
+    };
+  }
+
   if (config.dmxDriver === "null") {
     const { NullDriver } = (await import(
       "dmx-ts/dist/src/drivers/null.js"

--- a/server/src/dmx/universe-registry.ts
+++ b/server/src/dmx/universe-registry.ts
@@ -91,6 +91,7 @@ export function createUniverseRegistry(filePath: string): UniverseRegistry {
         devicePath: request.devicePath,
         driverType: request.driverType,
         ...(request.serialNumber ? { serialNumber: request.serialNumber } : {}),
+        ...(request.driverOptions ? { driverOptions: request.driverOptions } : {}),
       };
 
       universes = [...universes, universe];
@@ -127,6 +128,7 @@ export function createUniverseRegistry(filePath: string): UniverseRegistry {
         ...(changes.devicePath !== undefined ? { devicePath: changes.devicePath } : {}),
         ...(changes.driverType !== undefined ? { driverType: changes.driverType } : {}),
         ...(changes.serialNumber !== undefined ? { serialNumber: changes.serialNumber } : {}),
+        ...(changes.driverOptions !== undefined ? { driverOptions: changes.driverOptions } : {}),
       };
 
       universes = universes.map((u, i) => (i === index ? updated : u));

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -32,6 +32,7 @@ interface ScanPortsResponse {
 const RESTART_FIELDS: ReadonlySet<keyof PersistedSettings> = new Set([
   "dmxDriver",
   "dmxDevicePath",
+  "driverOptions",
   "port",
   "host",
 ]);

--- a/server/src/routes/universes.ts
+++ b/server/src/routes/universes.ts
@@ -1,11 +1,22 @@
 import type { FastifyInstance } from "fastify";
 import type { UniverseRegistry } from "../dmx/universe-registry.js";
 import type { FixtureStore } from "../fixtures/fixture-store.js";
+import type { DriverOptions } from "../types/protocol.js";
 
 interface UniverseRouteDeps {
   readonly registry: UniverseRegistry;
   readonly fixtureStore: FixtureStore;
 }
+
+const driverOptionsSchema = {
+  type: "object" as const,
+  properties: {
+    universe: { type: "number" as const },
+    port: { type: "number" as const },
+    sourceName: { type: "string" as const },
+    priority: { type: "number" as const },
+  },
+};
 
 const createSchema = {
   body: {
@@ -16,6 +27,7 @@ const createSchema = {
       devicePath: { type: "string" as const, minLength: 1 },
       driverType: { type: "string" as const, minLength: 1 },
       serialNumber: { type: "string" as const },
+      driverOptions: driverOptionsSchema,
     },
   },
 };
@@ -28,6 +40,7 @@ const updateSchema = {
       devicePath: { type: "string" as const, minLength: 1 },
       driverType: { type: "string" as const, minLength: 1 },
       serialNumber: { type: "string" as const },
+      driverOptions: driverOptionsSchema,
     },
   },
 };
@@ -48,7 +61,7 @@ export function registerUniverseRoutes(
     return universe;
   });
 
-  app.post<{ Body: { name: string; devicePath: string; driverType: string; serialNumber?: string } }>(
+  app.post<{ Body: { name: string; devicePath: string; driverType: string; serialNumber?: string; driverOptions?: DriverOptions } }>(
     "/universes",
     { schema: createSchema },
     async (req, reply) => {
@@ -66,7 +79,7 @@ export function registerUniverseRoutes(
     },
   );
 
-  app.patch<{ Params: { id: string }; Body: { name?: string; devicePath?: string; driverType?: string; serialNumber?: string } }>(
+  app.patch<{ Params: { id: string }; Body: { name?: string; devicePath?: string; driverType?: string; serialNumber?: string; driverOptions?: DriverOptions } }>(
     "/universes/:id",
     { schema: updateSchema },
     async (req, reply) => {

--- a/server/src/types/protocol.ts
+++ b/server/src/types/protocol.ts
@@ -3,6 +3,14 @@ import type { MovementConfig } from "../fixtures/movement-types.js";
 /** Default universe ID for backward compatibility */
 export const DEFAULT_UNIVERSE_ID = "default";
 
+/** Network driver options for ArtNet and sACN */
+export interface DriverOptions {
+  readonly universe?: number;
+  readonly port?: number;
+  readonly sourceName?: string;
+  readonly priority?: number;
+}
+
 /** Configuration for a single DMX universe */
 export interface UniverseConfig {
   readonly id: string;
@@ -10,6 +18,7 @@ export interface UniverseConfig {
   readonly devicePath: string;
   readonly driverType: string;
   readonly serialNumber?: string;
+  readonly driverOptions?: DriverOptions;
 }
 
 /** Request to create a new universe */
@@ -18,6 +27,7 @@ export interface AddUniverseRequest {
   readonly devicePath: string;
   readonly driverType: string;
   readonly serialNumber?: string;
+  readonly driverOptions?: DriverOptions;
 }
 
 /** Request to update an existing universe */
@@ -26,6 +36,7 @@ export interface UpdateUniverseRequest {
   readonly devicePath?: string;
   readonly driverType?: string;
   readonly serialNumber?: string;
+  readonly driverOptions?: DriverOptions;
 }
 
 /** Channel number (1-512) mapped to value (0-255) */


### PR DESCRIPTION
## Summary

- **Add ArtNet and sACN (E1.31) driver support** to the driver factory, using dmx-ts's built-in `ArtnetDriver` and `SACNDriver` — enables DMX output over Ethernet to network nodes and Art-Net gateways without a USB dongle
- **Wire `driverOptions`** (universe, port, sourceName, priority) through the full stack: `ServerConfig` → `PersistedSettings` → `UniverseConfig` → universe registry → route schemas
- **Conditional Web UI** in settings panel and setup wizard: serial drivers show COM port/scan; ArtNet shows target IP/universe/port; sACN shows universe/priority/source name
- **Add `artnet-listener.ts`** debug script for ad-hoc ArtNet packet inspection
- **10 new tests**: 6 driver-factory integration tests (real ArtNet/sACN socket binding) + 4 server-config unit tests

## Architecture

Zero changes above the driver layer — `UniverseManager`, `MultiUniverseCoordinator`, `DmxDispatcher`, color pipeline, and UDP server all remain untouched. ArtNet/sACN are connectionless UDP, so no `onDisconnect` wiring is needed; the `ResilientConnection` starts connected and stays there.

## Test plan

- [x] All 1623 tests pass (1602 existing + 10 new + 11 skipped)
- [x] TypeScript strict mode passes (`npx tsc --noEmit`)
- [ ] Manual: set driver to `artnet`, target `127.0.0.1`, verify DMX monitor updates
- [ ] Manual: set driver to `sacn`, verify packets via standalone receiver
- [ ] Manual: switch back to serial driver, verify COM port UI reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)