### PR TITLE
chore: release v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-04-08
+
+### Security
+- `basic-ftp` bumped via `npm audit fix` ([GHSA-chqc-8p9q-pq6q](https://github.com/advisories/GHSA-chqc-8p9q-pq6q) — high, FTP command injection via CRLF; transitive dev dep from puppeteer)
+- `brace-expansion` bumped via `npm audit fix` ([GHSA-f886-m6hf-6m8v](https://github.com/advisories/GHSA-f886-m6hf-6m8v) — moderate, ReDoS)
+- `vite` bumped transitively via `vitest` 4.1.3 ([GHSA-4w7w-66w2-5vf9](https://github.com/advisories/GHSA-4w7w-66w2-5vf9), [GHSA-v2wj-q39q-566r](https://github.com/advisories/GHSA-v2wj-q39q-566r), [GHSA-p9ff-h696-f583](https://github.com/advisories/GHSA-p9ff-h696-f583))
+
+### Changed
+- `@fastify/static` 9.0.0 → 9.1.0 (includes upstream `sendFile` option-override fix)
+- `vitest` 4.1.1 → 4.1.3
+- `@vitest/coverage-v8` 4.1.1 → 4.1.3
+- `@playwright/test` 1.58.2 → 1.59.1 (dev)
+- `@types/node` 25.5.0 → 25.5.2 (dev)
+
 ## [1.3.0] - 2026-03-12
 
 ### Added

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dmxr-server",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dmxr-server",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@fastify/cors": "^11.2.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dmxr-server",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "DMXr bridge server — receives fixture color data via HTTP and outputs DMX",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
Patch release rolling up 5 dependabot PRs and 1 security audit fix into v1.3.1.

**Bumps**
- `@fastify/static` 9.0.0 → 9.1.0 (runtime; upstream sendFile fix)
- `vitest` + `@vitest/coverage-v8` 4.1.1 → 4.1.3 (dev)
- `@playwright/test` 1.58.2 → 1.59.1 (dev)
- `@types/node` 25.5.0 → 25.5.2 (dev)

**Security**
- `basic-ftp` (high, GHSA-chqc-8p9q-pq6q) — via npm audit fix
- `brace-expansion` (moderate, GHSA-f886-m6hf-6m8v) — via npm audit fix
- `vite` transitive vulns cleared by vitest 4.1.3 (GHSA-4w7w-66w2-5vf9, GHSA-v2wj-q39q-566r, GHSA-p9ff-h696-f583)

## Test plan
- [x] `npm ci` clean
- [x] `npm audit --audit-level=high` → 0 vulnerabilities
- [x] `npm test` → 1612 passed, 11 skipped
- [x] `npx tsc --noEmit` → clean