### PR TITLE
fix(security): Phase 1 — close CRITICAL security vulnerabilities

### DIFF
--- a/.github/workflows/build-server.yml
+++ b/.github/workflows/build-server.yml
@@ -58,14 +58,26 @@ jobs:
 
       # --- Download portable Node.js binary ---
 
+      # SUPPLY-C2: all binary downloads are checksum-verified before inclusion
+      # in the release bundle. Node.js checksums come from the official
+      # SHASUMS256.txt; NSSM uses a hard-pinned hash (no upstream SHASUMS).
+
       - name: Download portable Node.js (Windows)
         if: matrix.node_platform == 'win'
         shell: pwsh
         run: |
           $nodeVersion = node -e "console.log(process.version)"
-          $url = "https://nodejs.org/dist/$nodeVersion/node-$nodeVersion-win-x64.zip"
+          $shaUrl = "https://nodejs.org/dist/$nodeVersion/SHASUMS256.txt"
+          $zipName = "node-$nodeVersion-win-x64.zip"
+          $url = "https://nodejs.org/dist/$nodeVersion/$zipName"
           Write-Host "Downloading $url"
           Invoke-WebRequest -Uri $url -OutFile node-portable.zip
+          Write-Host "Verifying checksum against $shaUrl"
+          Invoke-WebRequest -Uri $shaUrl -OutFile SHASUMS256.txt
+          $expected = (Get-Content SHASUMS256.txt | Select-String $zipName).ToString().Split(" ")[0]
+          $actual = (Get-FileHash node-portable.zip -Algorithm SHA256).Hash.ToLower()
+          if ($actual -ne $expected) { throw "SHA256 mismatch: expected $expected, got $actual" }
+          Write-Host "Checksum verified: $actual"
           Expand-Archive -Path node-portable.zip -DestinationPath node-extracted
           Copy-Item "node-extracted/node-$nodeVersion-win-x64/node.exe" -Destination node.exe
 
@@ -73,21 +85,35 @@ jobs:
         if: matrix.node_platform == 'linux'
         run: |
           NODE_VERSION=$(node -e "console.log(process.version)")
-          URL="https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-${{ matrix.node_arch }}.tar.xz"
+          ARCHIVE="node-$NODE_VERSION-linux-${{ matrix.node_arch }}.tar.xz"
+          URL="https://nodejs.org/dist/$NODE_VERSION/$ARCHIVE"
+          SHA_URL="https://nodejs.org/dist/$NODE_VERSION/SHASUMS256.txt"
           echo "Downloading $URL"
           curl -fsSL "$URL" -o node-portable.tar.xz
+          echo "Verifying checksum against $SHA_URL"
+          curl -fsSL "$SHA_URL" -o SHASUMS256.txt
+          grep "$ARCHIVE" SHASUMS256.txt | sha256sum -c -
           tar xf node-portable.tar.xz
           cp "node-$NODE_VERSION-linux-${{ matrix.node_arch }}/bin/node" node
 
       # --- Download NSSM (Windows only) ---
+      # SUPPLY-C2: NSSM has no upstream SHASUMS; hash is hard-pinned here.
+      # Update this hash when bumping the NSSM version.
 
       - name: Download NSSM
         if: matrix.node_platform == 'win'
         shell: pwsh
+        env:
+          NSSM_EXPECTED_SHA256: "dd15b0bd3541f954220b8c0622a40294b919dfd0e6635859e733f153ba34bceb"
         run: |
           $url = "https://github.com/ONLYOFFICE/nssm/releases/download/v2.24.1/nssm_x64.zip"
           Write-Host "Downloading NSSM from $url"
           Invoke-WebRequest -Uri $url -OutFile nssm.zip
+          $actual = (Get-FileHash nssm.zip -Algorithm SHA256).Hash.ToLower()
+          if ($actual -ne $env:NSSM_EXPECTED_SHA256) {
+            throw "NSSM SHA256 mismatch: expected $($env:NSSM_EXPECTED_SHA256), got $actual"
+          }
+          Write-Host "NSSM checksum verified: $actual"
           Expand-Archive -Path nssm.zip -DestinationPath nssm-extracted
           $nssm = Get-ChildItem -Path nssm-extracted -Filter nssm.exe -Recurse | Select-Object -First 1
           Copy-Item $nssm.FullName -Destination nssm.exe

--- a/.github/workflows/build-server.yml
+++ b/.github/workflows/build-server.yml
@@ -37,10 +37,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 22
 
@@ -131,14 +131,14 @@ jobs:
 
       - name: Upload release asset
         if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           draft: ${{ github.event_name != 'release' }}
           files: DMXr-Server-${{ matrix.target }}.${{ matrix.archive }}
 
       - name: Upload workflow artifact
         if: github.event_name != 'release' && !startsWith(github.ref, 'refs/tags/v')
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: DMXr-Server-${{ matrix.target }}
           path: DMXr-Server-${{ matrix.target }}.${{ matrix.archive }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,9 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 22
 
@@ -25,9 +25,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 22
 
@@ -42,9 +42,9 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 22
 

--- a/.github/workflows/dependency-health.yml
+++ b/.github/workflows/dependency-health.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 22
           cache: npm
@@ -54,7 +54,7 @@ jobs:
 
       - name: Create or update issue
         if: failure() || steps.contract.outcome == 'failure'
-        uses: peter-evans/create-issue-from-file@v6
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6
         with:
           title: "OFL API contract drift detected"
           content-filepath: server/issue-body.md

--- a/docs/SECURITY-AUDIT-2026-04-08.md
+++ b/docs/SECURITY-AUDIT-2026-04-08.md
@@ -1,0 +1,591 @@
+# DMXr Security Audit — 2026-04-08
+
+**Audit branch:** `audit/security-review-2026-04-08`
+**Audit commit:** main @ `a96963d` (v1.3.1)
+**Methodology:** 6 parallel specialist review passes across distinct threat surfaces
+**Findings:** 12 CRITICAL · 16 HIGH · 22 MEDIUM · 27 LOW · 5 INFO
+
+This audit evaluates DMXr as a networked DMX controller that drives real physical
+hardware (moving heads, high-intensity PARs, UV blacklights, strobe-capable
+fixtures). Physical-safety risks are scored as CRITICAL regardless of traditional
+exploitability because they can cause human injury (photosensitive epilepsy,
+motor runaway, thermal hazard) or property damage (gear strip, latched-on heat).
+
+---
+
+## Executive summary
+
+> **DMXr is structurally sound in several places** — robust UDP parser, strong
+> immutable-store pattern with atomic rename, no DOM-injection XSS sinks in the
+> web UI, Helmet CSP registered, API-key comparison is timing-safe, zero npm
+> advisories, no `pull_request_target` workflows, no secrets in the current tree.
+>
+> **But the authentication boundary is effectively non-existent on a default install.**
+> The combination of five independent defects collapses the entire trust model:
+>
+> 1. The HTTP auth middleware uses a prefix *allowlist* and **fails OPEN** for
+>    any path not in the list — roughly 60% of state-mutating routes
+>    (`/settings`, `/settings/restart`, `/universes`, `/config/import`, `/groups`,
+>    `/user-fixtures`, `/remap-presets`, `/metrics`, logs, diagnostics, SSE streams)
+>    are unauthenticated even when `API_KEY` is set. (AUTH-C1)
+> 2. The UDP DMXRC color transport is unauthenticated by design, has no
+>    source-address filter, and binds to `0.0.0.0` by default. (NET-H1/H2, DMX-C1)
+> 3. The default config binds the HTTP server to `0.0.0.0` and has no warning
+>    when `API_KEY` is empty. (AUTH-H5)
+> 4. `POST /settings/restart` calls `process.exit(1)` — unauthenticated → 1-packet
+>    LAN reboot loop. (AUTH-C2)
+> 5. `POST /universes` takes an arbitrary `devicePath` with no validation —
+>    unauthenticated → DMX output redirection. (AUTH-C4)
+>
+> **The physical-safety boundary is also soft.** Strobe channels have no
+> photosensitive-epilepsy (PSE) band exclusion; `applyRawUpdate` is a wide bypass
+> of motor guard, blackout state, and channel validation invoked by half the HTTP
+> routes (`/debug/raw`, `/fixtures/:id/test`, `/fixtures/:id/reset`, `/control/whiteout`,
+> `/groups/:id/flash`); runtime fixture additions don't update the safe-position
+> registry; and the "guaranteed shutdown blackout" is not synchronously guaranteed
+> because the `process.on("exit")` handler cannot flush the serial buffer.
+>
+> **The release pipeline** uses floating action tags (not pinned SHAs) and
+> downloads Node.js + NSSM binaries without checksum verification on a
+> **public** repository with a single code owner and `enforce_admins=false`.
+> A compromise of any pinned-by-tag action or a MITM of the Node.js download
+> silently backdoors every v1.x release bundle, which runs on user machines as
+> a privileged Windows service via NSSM.
+
+**Top 5 fixes, ranked by cost-weighted blast radius:**
+
+1. **Invert `api-key-auth.ts` to fail-closed with an explicit public allowlist.** Closes
+   AUTH-C1, C2, C3, C4, H1, H3, H4, H5. Single highest-impact change in the entire repo.
+   (~2 hours)
+2. **Bind UDP + HTTP to `127.0.0.1` by default.** Closes NET-H1, NET-H2, DMX-C1 for
+   99% of deployments. Requires a settings field `udpAllowedSources` (CIDR list) for
+   opt-in LAN exposure. (~3 hours)
+3. **Add a `StrobeGuard` with PSE-band exclusion (15–25 Hz)** mirroring the
+   existing `MotorGuard` pattern. Closes DMX-C3. Highest physical-harm ceiling in
+   the repo. (~6 hours)
+4. **Pin every GitHub Action to an immutable commit SHA** and add checksum
+   verification to the Node.js + NSSM downloads in `build-server.yml`. Closes
+   SUPPLY-C1 and SUPPLY-C2. (~1.5 hours)
+5. **Gate `applyRawUpdate` through `buildDmxUpdate`** and respect motor-guard +
+   blackout state. Closes DMX-C2. Prevents user-originated physical damage via the
+   "flash" test button on moving-head fixtures. (~4 hours)
+
+Total top-5 effort: **~16 hours**. This eliminates every CRITICAL and roughly half
+the HIGH-severity findings.
+
+---
+
+## Cross-layer correlations
+
+These are exploit chains that become severe only when two or more independently-
+scored findings combine.
+
+### Chain A — LAN-unauthenticated full-rig takeover (1 packet)
+`DMX-C1` (UDP binds 0.0.0.0, no auth) + `AUTH-H5` (default has no `API_KEY`) + `DMX-C3`
+(no strobe PSE cap). Any host on the same LAN can drive any connected fixture
+into a strobe-rate within the seizure-inducing band. No credentials required,
+no prior reconnaissance, no exploit skill. **Severity: CRITICAL (physical harm).**
+
+### Chain B — Permanent reboot loop
+`AUTH-C1` (auth bypass) + `AUTH-C2` (`POST /settings/restart` = `process.exit`).
+`curl -X POST http://DMXr:8080/settings/restart` in a shell loop = permanent
+outage until physical access. **Severity: CRITICAL.**
+
+### Chain C — Silent full-fixture wipe
+`AUTH-C1` + `AUTH-H1` (`/config/import` deletes all fixtures *before* validating
+the replacement payload). Single request destroys the entire fixture database with
+a crafted partial-valid import that fails mid-insert. **Severity: HIGH.**
+
+### Chain D — Persistent rebind + exfiltration
+`AUTH-C1` + `AUTH-C3` (`PATCH /settings` no schema, merges into disk) + `AUTH-C2`
+(restart). An attacker writes `{"host":"0.0.0.0","port":80,"apiKey":null}` then
+hits `/settings/restart`. Server rebinds to a public port with no auth.
+**Severity: CRITICAL.**
+
+### Chain E — Release-pipeline supply-chain RCE
+`SUPPLY-C1` (floating action tags) + `SUPPLY-C2` (unverified Node/NSSM downloads)
++ `SUPPLY-H1` (workflow-level `contents: write`) + `SUPPLY-H2` (single code owner,
+`enforce_admins: false`). A tag compromise of `actions/checkout`, `actions/setup-node`,
+or `softprops/action-gh-release` inserts a backdoor into a portable Node binary that
+ships as a Windows service. Every v1.x download post-compromise is owned at the
+host level. **Severity: CRITICAL (scales to every end user).**
+
+### Chain F — False-confidence blackout
+`DMX-C5` (blackout silently returns success when USB is unplugged) + `DMX-C4`
+(sync `exit` handler can't flush serial buffer). Operator pulls the USB during a
+show, hits the UI blackout button, sees a green checkmark, walks away — fixtures
+remain latched at whatever value they had before the disconnect. **Severity:
+CRITICAL (physical — fire, heat, runaway motors).**
+
+### Chain G — Rogue mDNS server hijacks SignalRGB plugin
+`NET-M3` (mDNS advertises on all interfaces) + `FRONT-H1` (SignalRGB plugin trusts
+any `_dmxr._tcp.local` advertisement). A hostile device on the LAN advertises as
+DMXr; SignalRGB clients auto-discover and send color data to the attacker's
+collector. Since the plugin also opens `"http://" + modelData.host + ":" + port`
+from QML with no allowlist, the attacker can additionally drive-by browse the
+user. **Severity: HIGH.**
+
+---
+
+## CRITICAL findings (12)
+
+### AUTH-C1 · API-key auth prefix allowlist fails open
+**Layer:** AuthN/AuthZ · **Effort:** M
+
+`server/src/middleware/api-key-auth.ts:4-17, 32-41` — `API_PREFIXES` lists only
+`/fixtures, /update, /control, /ofl, /libraries, /search, /signalrgb, /debug`.
+Any URL not matching a prefix **returns early (line 33–35)** without auth. The
+unauthenticated routes include `/settings/*`, `/universes/*`, `/config/*`,
+`/groups/*` (which mutate DMX state!), `/user-fixtures/*`, `/remap-presets/*`,
+`/metrics`, `/api/logs/*`, `/api/diagnostics/*`, `/api/dmx/*`, `/api/settings/*`.
+
+**Fix:** Invert the logic — fail closed. Register `registerApiKeyAuth` as a
+`preHandler` only on an explicit public-route exemption list (`/health`, static,
+favicon). Prefer route-level `config: { public: true }` tagging.
+
+### AUTH-C2 · `POST /settings/restart` is a 1-packet LAN DoS
+**Layer:** AuthN/AuthZ · **Effort:** S
+
+`server/src/routes/settings.ts:86-96` — unauthenticated (AUTH-C1), calls
+`process.exit(1)` after a 500ms delay. Relies on a service manager (NSSM,
+systemd) to restart — sustained reboot loop trivially achievable.
+
+**Fix:** Require auth + `config: { rateLimit: { max: 2, timeWindow: '1 hour' } }`.
+Require a short-lived confirmation token.
+
+### AUTH-C3 · `PATCH /settings` has no schema, merges any body into disk
+**Layer:** AuthN/AuthZ · **Effort:** S
+
+`server/src/routes/settings.ts:58-74` + `server/src/config/settings-store.ts:97-101`
+— handler casts `request.body as Partial<PersistedSettings>` with no Fastify
+schema; `update()` does `{ ...current, ...partial }` with no allowlist.
+`isValidSettings()` exists in the store but is only invoked on `load()`, not
+on `update()`. Attacker writes arbitrary `host`, `port`, `dmxDevicePath`,
+arbitrary junk keys. Persists across restart.
+
+**Fix:** Add JSON schema with `additionalProperties: false` on the route AND
+call `isValidSettings` inside `update()` with key-allowlist filtering.
+
+### AUTH-C4 · `POST /universes` accepts arbitrary `devicePath`/`driverType`
+**Layer:** AuthN/AuthZ · **Effort:** S
+
+`server/src/routes/universes.ts:64-98` — unauthenticated (AUTH-C1), no
+`additionalProperties: false`, no maxLength on strings, no enum on `driverType`.
+Attacker redirects DMX output to an arbitrary serial or network endpoint and
+persists the change.
+
+**Fix:** Auth + strict schema + enum constraint matching `VALID_DRIVERS`.
+
+### DMX-C1 · UDP color transport unauthenticated, binds 0.0.0.0
+**Layer:** Network + DMX · **Effort:** M
+
+`server/src/udp/udp-color-server.ts:49`, `server/src/config/server-config.ts:83`.
+The DMXRC binary protocol has no key or nonce. Any LAN host can stream color,
+movement, and `FLAG_BLACKOUT` packets at unbounded rate. Combined with DMX-C3
+(no strobe PSE cap) this is a **human-harm vector**.
+
+**Fix:** Default UDP bind to `127.0.0.1`. Add `udpAllowedSources` CIDR list
+(loopback + RFC1918 by default). Derive an HMAC key from `API_KEY` and require
+signed packets when a key is configured.
+
+### DMX-C2 · `applyRawUpdate` bypasses motor guard, blackout, validation, and locked channels
+**Layer:** DMX · **Effort:** M
+
+`server/src/dmx/universe-manager.ts:324-341` writes directly to the serial
+driver without `buildDmxUpdate`, without clamping, without honoring
+`blackoutActive`, without respecting `lockedChannels`, and without motor-guard.
+Route paths that depend on it:
+
+- `/debug/raw` (`debug.ts:97`)
+- `/fixtures/:id/test` flash paths (`fixture-test.ts:136,170,202`) — the
+  per-channel flash button assigns `255` even to Pan/Tilt channels on a SLM70S
+  moving head, slamming it into the mechanical hard stop.
+- `/fixtures/:id/reset` (`fixture-reset.ts:71`)
+- `/control/whiteout` (`control-modes.ts:54`)
+- `/groups/:id/blackout|whiteout|flash|resume` (`group-control.ts:92,129,173,189,228`)
+
+**Fix:** Route `applyRawUpdate` through `buildDmxUpdate`; add an explicit
+`{ bypassBlackout: true }` opt-in only for the narrow bootstrap restore path.
+In `buildFlashValues`, detect motor channel types and clamp via `clampMotor`;
+for Strobe channels use `channel.defaultValue` — never unconditional 255.
+
+### DMX-C3 · No photosensitive-epilepsy (PSE) guard on Strobe channels
+**Layer:** DMX (physical safety) · **Effort:** M
+
+`server/src/fixtures/pipeline-stages.ts:133-139`,
+`server/src/fixtures/fixture-override-service.ts:49-50`. Strobe channels
+are written as `0 | 255 | defaultValue` with no reference to the W3C WCAG 2.3.1
+photosensitive-epilepsy band (15–25 Hz). OFL capability frequency metadata is
+not consulted. A legitimate user dragging the override slider OR any
+unauthenticated UDP sender (DMX-C1) can produce seizure-inducing output.
+
+**Fix:** Build a `StrobeGuard` parallel to `MotorGuard`. Per fixture, derive
+`strobeHzSafeRange` from OFL capabilities (denying 10–25 Hz by default). When
+capabilities are absent, clamp `Strobe`/`ShutterStrobe` values to
+`{0, defaultValue}`. Opt-in override only for power users with a persistent
+warning banner.
+
+### DMX-C4 · "Guaranteed shutdown blackout" is not synchronously guaranteed
+**Layer:** DMX (physical safety) · **Effort:** M
+
+`server/src/bootstrap/shutdown.ts:34-40` registers a `process.on("exit")` handler
+that calls `manager.blackout()`. But Node's sync `exit` phase does not run timers
+or microtasks. The blackout frame is written into dmx-ts's in-memory send buffer
+and never leaves the serial port. The flushable path (`flushAndClose`) is `async`
+and only runs on the happy-path SIGINT/SIGTERM; if `uncaughtException` leaks into
+sync exit, fixtures latch at pre-crash values — stuck hot lamp / mid-motion
+moving head.
+
+**Fix:** In the `exit` handler, synchronously emit a zero frame via the
+underlying `SerialPort.write(Buffer.alloc(513, 0))`. Add an integration test
+that kills the process with `SIGABRT` and verifies a zero frame on loopback.
+Document `SIGKILL` as out-of-scope and recommend a hardware DMX watchdog for
+mission-critical installs.
+
+### DMX-C5 · Blackout silently reports success when USB is disconnected
+**Layer:** DMX (physical safety) · **Effort:** S
+
+`server/src/dmx/resilient-connection.ts:178-197` — proxy universe drops writes
+when `currentConnection === null`. `universe-manager.safeSend` wraps that in
+try/catch and returns `{ ok: true }` because no exception. UI shows a green
+checkmark; fixtures remain latched.
+
+**Fix:** Return `{ ok: false, error: "no active DMX connection" }` from the
+proxy. `shutdown.ts` should log `BLACKOUT FAILED — DMX disconnected` prominently
+and block exit for a configurable grace period while attempting reconnect.
+
+### DMX-C6 · Safe motor positions registered only at boot
+**Layer:** DMX (physical safety) · **Effort:** S
+
+`server/src/bootstrap/fixture-init.ts:24-25` calls `computeSafePositions()` once
+at startup. No route re-registers after CRUD. Adding an SLM70S via the web UI
+leaves its pan/tilt channels absent from `safePositions` — next `/control/blackout`
+sends `0` (mechanical hard stop) instead of `128`, risking gear strip on first
+blackout.
+
+**Fix:** Subscribe to `fixtureStore` change events (or call in each CRUD route);
+re-run `computeSafePositions` → `registerSafePositions` on every fixture mutation.
+
+### SUPPLY-C1 · Every GitHub Action pinned to a floating major tag
+**Layer:** Supply chain · **Effort:** S
+
+`.github/workflows/ci.yml`, `build-server.yml`, `dependency-health.yml` — all
+actions use `@v6`-style floating tags. Repo is **public**. Tag compromise (via
+account takeover, force-push to `v6`, malicious maintainer) instantly executes
+attacker code with `build-server.yml`'s `contents: write` token, backdooring
+every release bundle.
+
+Affected: `actions/checkout@v6`, `actions/setup-node@v6`,
+`softprops/action-gh-release@v2`, `actions/upload-artifact@v7`,
+`peter-evans/create-issue-from-file@v6`.
+
+**Fix:** Pin to 40-char commit SHAs with version as a trailing comment:
+`uses: actions/checkout@b4ffde65... # v4.1.1`. Dependabot auto-bumps SHA pins.
+
+### SUPPLY-C2 · Release bundles download Node.js + NSSM without checksum verification
+**Layer:** Supply chain · **Effort:** S
+
+`.github/workflows/build-server.yml:61-93` — three unauthenticated downloads:
+- `https://nodejs.org/dist/$V/node-$V-win-x64.zip` (no `SHASUMS256.txt` verify)
+- `https://nodejs.org/dist/$V/node-$V-linux-${arch}.tar.xz` (no verify)
+- `https://github.com/ONLYOFFICE/nssm/releases/.../nssm_x64.zip` (no hash pin)
+
+These binaries ship inside the portable server bundle and run as a privileged
+service on user machines. A TLS MITM on the GitHub runner, a mirror compromise,
+or a `ONLYOFFICE/nssm` takeover silently backdoors every downstream DMXr install.
+
+**Fix:**
+```yaml
+curl -fsSLO https://nodejs.org/dist/$V/SHASUMS256.txt
+grep node-$V-... SHASUMS256.txt | sha256sum -c -
+```
+For NSSM: hard-code expected SHA-256 or vendor it. Fail the job on mismatch.
+
+---
+
+## HIGH findings (16)
+
+### NET-H1 · UDP ping echo → reflection / amplification
+`server/src/udp/udp-color-server.ts:106-115`. `FLAG_PING` triggers a reply of up
+to ~1290 B for a ~20 B request (≈64× amplification). No source validation, no
+rate limit. With `0.0.0.0` bind, DMXr can be weaponized as a reflector by a
+spoofed-source DDoS.
+**Fix:** Reply with fixed-size 15 B header only; drop non-RFC1918 sources;
+token-bucket per source (10/s).
+
+### NET-H2 · UDP server binds 0.0.0.0 with no source allow-list
+Subsumed in DMX-C1. Listed independently by the network agent to capture the
+non-physical-safety DoS dimension.
+**Fix:** See DMX-C1.
+
+### AUTH-H1 · `/config/import` replace-mode deletes fixtures before full validation
+`server/src/routes/config.ts:193-246`. Pre-validation catches required fields +
+intra-batch conflicts, not schema/reference integrity. Delete happens on line
+195–197; `addBatch` throws on line 235 → 500 + data-loss warning in the log.
+Unauthenticated (AUTH-C1).
+**Fix:** Dry-run add against a cloned store before destructive delete.
+
+### AUTH-H2 · `/update` schema accepts unbounded integer keys, no clamping
+`server/src/routes/update.ts:11-23`. `channels.additionalProperties: {type:"number"}`
+with no min/max, no `maxProperties`, uses `number` (accepts floats), no
+`propertyNames` pattern.
+**Fix:** `type:"integer", minimum:0, maximum:255`, `maxProperties:512`,
+`propertyNames:{pattern:"^[1-9][0-9]{0,2}$"}`.
+
+### AUTH-H3 · `/health` + `/metrics` leak device path and internals unauthenticated
+`server/src/routes/health.ts:68-92`, `metrics.ts:16-42`. Returns
+`dmxDevicePath` (COM port / `/dev/ttyUSB0`), `serverId`, connection error
+titles, reconnect attempts, latency histograms, UDP packet counts.
+**Fix:** Keep `/health` minimal (`{status, version, uptime}`); move detail to
+`/health/detailed` behind auth. Gate `/metrics` behind auth or a separate
+`METRICS_API_KEY`.
+
+### AUTH-H4 · `/api/logs` + SSE stream leak internal errors, paths, fixture names unauthenticated
+`server/src/routes/logs.ts:20-120`. Buffer contains OFL failure stack bits,
+pipeline debug lines, fixture names, error suggestions. `limit` querystring is
+`parseInt` with no upper bound.
+**Fix:** Require auth; clamp `limit` ≤ 1000; scrub stack traces before buffering.
+
+### AUTH-H5 · Empty `API_KEY` env silently disables auth for every route
+`server/src/server.ts:147-149`. No startup warning. On a default laptop install
+connected to untrusted Wi-Fi, full DMX + restart control is exposed to any LAN
+peer.
+**Fix:** Log a prominent warning at startup when `apiKey` is unset AND
+`host !== "127.0.0.1"`. Refuse non-loopback bind without either a key or
+an explicit `INSECURE_NO_AUTH=1` opt-out.
+
+### DMX-H1 · Reconnect replay re-applies stale channels without ramp
+`server/src/dmx/resilient-connection.ts:139-144`. After USB reconnect, the
+snapshot is replayed verbatim; no interpolation, no safe-position pre-seed on
+the new connection. Pan/tilt snaps instantaneously to the pre-disconnect target.
+**Fix:** Pipe the snapshot through a 500ms ramp; seed `safePositions` as the
+first frame after reconnect.
+
+### DMX-H2 · `whiteout` drives Strobe channels of un-registered fixtures to 255
+`server/src/routes/control-modes.ts:30-71`. `dispatcher.whiteout()` fills the
+entire 512-byte universe with 255 before overlay, including Strobe channel
+offsets whose fixture isn't registered in `safePositions`.
+**Fix:** Extend `registerSafePositions` to hold strobe-safe caps (0 for Strobe).
+Couples with DMX-C3.
+
+### DMX-H3 · `/debug/raw` accepts fractional DMX addresses
+`server/src/routes/debug.ts:77-94`. Channel key filter is `>=1 && <=512`, not
+`Number.isInteger`. A fractional key reaches `applyRawUpdate` → dmx-ts with
+unpredictable behavior.
+**Fix:** `Number.isInteger(dmxAddr)` check. Better: refactor per DMX-C2.
+
+### DMX-H4 · UDP server has no rate limit → serial-bus DoS
+`server/src/udp/udp-color-server.ts:59`. Every packet triggers a
+`manager.applyFixtureUpdate` call. 10k pps starves Node's event loop and
+delays the 25ms dmx-ts send tick, misfiring the watchdog.
+**Fix:** Coalesce updates (latest-wins per 20ms tick); per-source leaky bucket.
+
+### DMX-H5 · Packet timestamp decode has no sanity clamp → metrics poisoning
+`server/src/udp/packet-parser.ts:75-77`. Crafted timestamps produce negative
+`networkMs` which pollute `latency-tracker`.
+**Fix:** `if (networkMs < 0 || networkMs > 60_000) skip`.
+
+### FRONT-H1 · SignalRGB plugin trusts mDNS TXT + `/health` JSON from any LAN peer
+`DMXr.js:444-475` (`DiscoveryService.connect`), `:600` (`fixture.name` → controller
+display name), `DMXr.qml:342` (`Qt.openUrlExternally("http://"+host+":"+port)`).
+Any LAN device advertising `_dmxr._tcp.local.` is accepted. `host`/`port`/`serverId`
+have no allowlist. Rogue servers inject controllers and can force drive-by
+browsing via "Open Web Manager".
+**Fix:** Validate `dev.ip` is RFC1918; regex-lock `serverId`/`host`; validate
+`udpPort` range; in QML, allowlist `host` to `^[a-zA-Z0-9.-]+$`.
+
+### SUPPLY-H1 · `build-server.yml` uses repo-wide `contents: write`
+`.github/workflows/build-server.yml:11-12`. Unscoped to jobs; inherited by every
+step, including the unverified binary downloads.
+**Fix:** Move `permissions` to job level; isolate `contents: write` to the final
+release-upload job that reads from `upload-artifact`.
+
+### SUPPLY-H2 · `enforce_admins: false` + `required_signatures: false` + single owner
+`gh api repos/thewrz/DMXr/branches/main/protection`. Branch protection is
+effectively advisory for the sole code owner. Stolen token pushes directly to
+`main` and triggers the release pipeline.
+**Fix:** Enable both. Add a secondary code owner (or trusted bot). Enforce
+hardware 2FA.
+
+### SUPPLY-H3 · No SBOM / provenance on release artifacts (public repo, privileged install)
+`.github/workflows/build-server.yml`. Release bundles contain `node_modules/` and
+a portable Node runtime; end users have no way to verify what they installed.
+**Fix:** Add `actions/attest-build-provenance@<sha>`. Publish a CycloneDX SBOM
+via `anchore/sbom-action`. Attach both to GH releases.
+
+---
+
+## MEDIUM findings (22)
+
+Condensed — see individual agent reports for full context.
+
+| ID | Layer | Title |
+|----|-------|-------|
+| NET-M1 | Network | SSE endpoints have no subscriber cap or rate limit (FD exhaustion) |
+| NET-M2 | Network | Fastify has no `connectionTimeout`/`requestTimeout`/`keepAliveTimeout` (slow-loris) |
+| NET-M3 | Network | mDNS advertises on all interfaces; TXT leaks `serverId`/`serverName` |
+| NET-M4 | Network | No content-type enforcement on POST routes (CSRF vector via `text/plain`) |
+| AUTH-M1 | Auth | Many route schemas lack `additionalProperties: false` → extra fields reach stores |
+| AUTH-M2 | Auth | Unbounded `maxItems` on `/user-fixtures`, `/groups`, `/fixture-batch` arrays |
+| AUTH-M3 | Auth | `parseInt(limit, 10)` unbounded on `/api/logs`, `/api/diagnostics` |
+| AUTH-M4 | Auth | SSE endpoints bypass `@fastify/rate-limit` after `reply.hijack()` |
+| AUTH-M5 | Auth | Timing-safe compare short-circuits on length mismatch (reveals key length) |
+| AUTH-M6 | Auth | `/ofl/*`, `/search` have no per-route limit → outbound amplification to OFL API |
+| AUTH-M7 | Auth | CSP `'unsafe-eval'` + `'unsafe-inline'` (Alpine non-CSP build) |
+| AUTH-M8 | Auth | CORS regex allows any port on LAN ranges (low impact; `credentials:false`) |
+| FS-F1 | Filesystem | `settings-store.save()` lacks the documented `saveChain` mutex (races) |
+| FS-F2 | Filesystem | `/config/import` doesn't type-validate `settings` → persistent DoS via `parseInt(base.port)` on restart |
+| DMX-M1 | DMX | `applyRawUpdate` writes `NaN` keys into `activeChannels` → downstream JSON crashes |
+| DMX-M2 | DMX | `fixture-validator.ts` doesn't reject out-of-range channel-override values on load |
+| DMX-M3 | DMX | `flushAndClose` pokes a private `_readyToWrite` field on dmx-ts (fragile) |
+| DMX-M4 | DMX | `driver-factory.onDisconnect` leaks listeners on reconnect |
+| DMX-M5 | DMX | `dispatcher.blackout()` only returns primary-manager result → silent partial blackout |
+| FRONT-M1 | Frontend | CSP allows `'unsafe-eval'` + `'unsafe-inline'` (same as AUTH-M7) |
+| FRONT-M2 | Frontend | Plugin update check fetches raw JS from GitHub (log sink only today) |
+| FRONT-M3 | Frontend | Plugin update URL hardcoded to `thewrz/DMXr` account (takeover risk) |
+| SUPPLY-M1 | Supply | `better-sqlite3` + `@serialport/bindings-cpp` run install scripts on every `npm ci` |
+| SUPPLY-M2 | Supply | Dependabot has no groups/reviewers → 1-signer merges to release pipeline |
+| SUPPLY-M3 | Supply | `dependency-health.yml` runs `npm ci` with `issues:write` token (install-script escalation) |
+
+---
+
+## LOW findings (27)
+
+Condensed summary. Full details in individual agent reports archived with this audit.
+
+- **NET-L1/L2/L3** — `/api/logs?limit=` unbounded, packet timestamp sanity, mDNS republish race
+- **AUTH-L1/L2/L3/L4/L5/L6** — `universes.ts` error echoes, `Content-Disposition` filename, `request.body as X` coercion, error handler masking, body limits, prototype-pollution review
+- **FS-F3b/F4/F5/F7/F8** — OFL cache symlink TOCTOU, `clear()` unlink without `lstat`, remap preset keys unvalidated, world-readable file mode (no secrets today), `component-writer.ts` non-atomic
+- **DMX-L1/L2/L3/L4/L5** — `/debug/raw` log leak, `latency-tracker` bounds, `movement-interpolator` speed clamp, `resilient-connection` double-schedule, `udp-color-server` post-start error path
+- **FRONT-L1/L2/L3/L4** — synchronous XHR no timeout, `frame-ancestors` not in explicit CSP, no SRI on `alpine.min.js`, IPv6 `host:port` parse
+- **SUPPLY-L1/L2/L3/L4** — `audit-level=high` not `moderate`, no `setup-node` cache, `fsevents` duplicate, `engines.node>=18` (EOL)
+
+---
+
+## Scope-covered clean items
+
+These were explicitly checked and found clean — they belong in the report because
+"absence of evidence" should be a documented negative result.
+
+- **UDP DMXRC parser robustness** — magic + version + length checks, all
+  `readUInt*BE` guarded, truncated-packet tests exist, movement-section math is
+  correct, `Buffer.alloc` (not `allocUnsafe`). **No parser CVE candidates.**
+- **Art-Net / sACN ingress** — neither protocol has a listener; both are
+  egress-only via dmx-ts. Zero ingress surface in DMXr's own code.
+- **SignalRGB plugin code execution** — `DMXr.js` has zero `eval`/`Function`/
+  `setTimeout(string)`/DOM-sink assignments. Server responses are parsed via
+  `JSON.parse` only. Plugin is strictly receive-safe as a design property.
+- **DMXr.qml** — no `eval`, no `Qt.createQmlObject`, no `WebEngineView`, no
+  `Loader { source: untrusted }`.
+- **Web UI XSS sinks** — all 7 `x-html` directives are either hardcoded SVG
+  lookups or escape-sanitized via `escapeHtml`. No DOM-injection sinks anywhere
+  in `server/public/js/*`.
+- **No `localStorage` secret caching.**
+- **No `postMessage` listeners.**
+- **Atomic tmp+rename** used consistently in all 6 JSON stores (settings lacks
+  the `saveChain` per FS-F1 but the write itself is atomic).
+- **OFL disk cache path-traversal fix** is correct and exhaustive for `../`,
+  absolute, UNC, drive letter, null byte, and unicode NFC/NFD vectors. Symlink
+  TOCTOU remains (FS-F3b).
+- **API key lives only in `process.env.API_KEY`** — never written to disk, never
+  logged, never persisted. Error handler masks 5xx bodies. Timing-safe compare
+  is used (modulo the length-reveal in AUTH-M5).
+- **No `pull_request_target` workflows** — zero fork-secret exposure.
+- **No secrets in working tree** — only `test-secret-key-123` in
+  `api-key-auth.test.ts:16` (legitimate fixture). No AKIA, no `ghp_`, no `sk-`,
+  no PEM headers, no bearer tokens.
+- **No secrets in git history** — the `deployment.md` commits referenced in
+  project memory (`d3ed9dee..8840de0`) **do not exist in this repo**. Memory
+  note is stale.
+- **No typosquats** — every dep resolves to a well-known package on
+  `registry.npmjs.org` with `sha512-` integrity hashes. No alternate registries.
+- **`npm audit --audit-level=low`** → **0 vulnerabilities** (post v1.3.1).
+- **`CODEOWNERS`** present. Single owner — see SUPPLY-H2.
+- **Helmet CSP + X-Frame-Options** registered on all routes.
+
+---
+
+## Prioritized remediation roadmap
+
+### Phase 1 — stop the bleeding (~16 hours)
+Closes every CRITICAL and ~50% of HIGH. Recommended order:
+
+| Order | Finding(s) | Effort | Closes |
+|-------|-----------|--------|--------|
+| 1 | **AUTH-C1** — invert auth to fail-closed | 2h | C1, C2, C3, C4, H1, H3, H4, H5 (partial) |
+| 2 | **DMX-C1 / NET-H1/H2** — bind UDP+HTTP to 127.0.0.1 by default | 3h | DMX-C1, NET-H1, NET-H2, AUTH-H5 (partial) |
+| 3 | **DMX-C3** — StrobeGuard with PSE-band exclusion | 6h | DMX-C3, DMX-H2 |
+| 4 | **SUPPLY-C1/C2** — pin action SHAs + checksum Node/NSSM | 1.5h | SUPPLY-C1, SUPPLY-C2 |
+| 5 | **DMX-C2** — gate `applyRawUpdate` through `buildDmxUpdate` | 4h | DMX-C2, DMX-H3, DMX-M1 |
+
+### Phase 2 — physical-safety remainder (~6 hours)
+
+| Finding | Effort | Notes |
+|---------|--------|-------|
+| DMX-C4 — synchronous exit-handler serial write | 4h | Requires reaching into dmx-ts internals |
+| DMX-C5 — honest disconnect reporting from resilient-connection | 2h | One-liner + shutdown.ts log message |
+| DMX-C6 — re-register safe positions on CRUD | 1h | Subscribe to fixtureStore events |
+| DMX-H1 — reconnect replay ramp | 4h | Couples with DMX-C6 |
+
+### Phase 3 — release-pipeline hardening (~4 hours)
+
+| Finding | Effort |
+|---------|--------|
+| SUPPLY-H1 — scope `contents: write` to release job | 1h |
+| SUPPLY-H2 — `enforce_admins` + `required_signatures` + 2FA | 15m config + co-maintainer |
+| SUPPLY-H3 — SBOM + provenance attestation | 2h |
+| SUPPLY-M1 — `npm ci --ignore-scripts` on non-build jobs | 1h |
+
+### Phase 4 — input validation & rate-limit sweep (~8 hours)
+
+| Finding | Effort |
+|---------|--------|
+| AUTH-M1 — blanket `additionalProperties: false` | 2h |
+| AUTH-M2 — `maxItems` on arrays | 1h |
+| AUTH-M3 — `parseInt` clamps | 30m |
+| AUTH-M4 — SSE subscriber cap per IP | 2h |
+| AUTH-M6 — per-route rate limits on OFL/search | 30m |
+| NET-M2 — Fastify timeouts | 15m |
+| AUTH-H2 — tighten `/update` schema | 30m |
+| FS-F2 — type-validate `/config/import` settings | 1h |
+| FS-F1 — add saveChain to settings-store | 15m |
+
+### Phase 5 — frontend & lower-severity polish (~4 hours)
+
+| Finding | Effort |
+|---------|--------|
+| FRONT-H1 — validate mDNS TXT + QML host allowlist | 1h |
+| FRONT-L1 — XHR timeouts on plugin sync paths | 30m |
+| FRONT-L2 — add `frameAncestors` to CSP | 2m |
+| FS-F6 — saveChain error recovery (`.catch` reset) | 30m |
+| FS-F7 — `mode: 0o600` on store writes | 15m |
+| DMX-M2 to M5 — dispatcher/validator/driver polish | 1.5h |
+
+**Grand total:** ~38 hours to close all CRITICAL + HIGH + MEDIUM findings. Phase
+1 alone (16h) eliminates the practical exploitability of the entire repo.
+
+---
+
+## Appendix A — agent-by-agent scope coverage
+
+| Agent | Scope | Files read (primary) |
+|-------|-------|----------------------|
+| 1. Network | UDP, mDNS, SSE, Fastify | `udp/*`, `mdns/advertiser.ts`, `routes/monitor.ts`, `routes/logs.ts`, `server.ts`, `DMXr.js` |
+| 2. Auth | Middleware, all 25 routes | `middleware/api-key-auth.ts`, `routes/*.ts`, `server.ts`, `config/settings-store.ts` |
+| 3. Filesystem | Stores, OFL cache | `config/*`, `fixtures/{fixture,group,user-fixture}-store.ts`, `libraries/*`, `ofl/*`, `dmx/universe-registry.ts`, `signalrgb/component-writer.ts` |
+| 4. DMX hardware | Physical safety + DMX | `dmx/*`, `fixtures/{motor-guard,pipeline-stages,color-pipeline,channel-mapper,fixture-override-service,movement-interpolator}.ts`, `bootstrap/*`, `metrics/latency-tracker.ts` |
+| 5. Frontend | Web UI + plugin | `server/public/index.html`, `server/public/js/*` (33 mixins), `DMXr.js`, `DMXr.qml` |
+| 6. Supply chain | CI/CD + deps | `.github/workflows/*.yml`, `.github/dependabot.yml`, `CODEOWNERS`, `package.json`, `package-lock.json`, branch protection via `gh api` |
+
+No scope overlap — each file has exactly one primary reviewer.
+
+## Appendix B — finding-ID scheme
+
+- `NET-*` — network I/O and protocols (agent 1)
+- `AUTH-*` — authentication, authorization, input validation (agent 2)
+- `FS-*` — filesystem and config persistence (agent 3)
+- `DMX-*` — DMX hardware, resilient connection, physical safety (agent 4)
+- `FRONT-*` — frontend UI and SignalRGB plugin (agent 5)
+- `SUPPLY-*` — supply chain, CI/CD, release pipeline (agent 6)
+
+Severity letters: `C` = CRITICAL, `H` = HIGH, `M` = MEDIUM, `L` = LOW.

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2132,9 +2132,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.1.tgz",
-      "integrity": "sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
+      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/server/src/config/server-config.test.ts
+++ b/server/src/config/server-config.test.ts
@@ -19,7 +19,7 @@ describe("loadConfig", () => {
     const config = loadConfig();
 
     expect(config.port).toBe(8080);
-    expect(config.host).toBe("0.0.0.0");
+    expect(config.host).toBe("127.0.0.1");
     expect(config.dmxDriver).toBe("null");
     expect(config.dmxDevicePath).toBe("auto");
     expect(config.logLevel).toBe("info");

--- a/server/src/config/server-config.ts
+++ b/server/src/config/server-config.ts
@@ -24,13 +24,13 @@ export interface ServerConfig {
   };
 }
 
-const VALID_DRIVERS = [
+export const VALID_DRIVERS = [
   "null",
   "enttec-usb-dmx-pro",
   "enttec-open-usb-dmx",
   "artnet",
   "sacn",
-];
+] as const;
 
 export function loadConfig(
   persisted?: Partial<PersistedSettings>,
@@ -51,7 +51,7 @@ export function loadConfig(
   const dmxDriver =
     process.env["DMX_DRIVER"] ?? base.dmxDriver ?? "null";
 
-  if (!VALID_DRIVERS.includes(dmxDriver)) {
+  if (!(VALID_DRIVERS as readonly string[]).includes(dmxDriver)) {
     throw new Error(
       `Invalid DMX_DRIVER: "${dmxDriver}". Must be one of: ${VALID_DRIVERS.join(", ")}`,
     );

--- a/server/src/config/server-config.ts
+++ b/server/src/config/server-config.ts
@@ -80,7 +80,9 @@ export function loadConfig(
   return {
     port: rawPort,
     udpPort: Number.isFinite(rawUdpPort) && rawUdpPort >= 0 ? rawUdpPort : 0,
-    host: process.env["HOST"] ?? base.host ?? "0.0.0.0",
+    // DMX-C1: default to loopback. Use HOST=0.0.0.0 or settings.host to
+    // bind to all interfaces (requires API_KEY or explicit INSECURE_NO_AUTH=1).
+    host: process.env["HOST"] ?? base.host ?? "127.0.0.1",
     dmxDriver,
     dmxDevicePath:
       process.env["DMX_DEVICE_PATH"] ?? base.dmxDevicePath ?? "auto",

--- a/server/src/config/settings-store.test.ts
+++ b/server/src/config/settings-store.test.ts
@@ -192,6 +192,53 @@ describe("createSettingsStore", () => {
       expect(a).not.toBe(b);
     });
   });
+
+  describe("AUTH-C3 update input validation", () => {
+    beforeEach(async () => {
+      await store.load();
+    });
+
+    it("strips unknown keys from partial (prototype-pollution defense)", async () => {
+      // Cast through unknown because the type forbids extra keys, but at
+      // runtime a malicious PATCH body can carry them.
+      await store.update({
+        port: 9001,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        foo: "bar",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        __proto__: { polluted: true },
+      } as unknown as Partial<PersistedSettings>);
+
+      const current = store.get();
+      expect(current.port).toBe(9001);
+      expect((current as unknown as Record<string, unknown>).foo).toBeUndefined();
+      // Proto pollution check
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    it("rejects wrong-type values by throwing", async () => {
+      await expect(
+        store.update({
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          port: "evil" as any,
+        }),
+      ).rejects.toThrow();
+    });
+
+    it("ignores attempts to change serverId (read-only)", async () => {
+      const before = store.get().serverId;
+      await store.update({ serverId: "attacker-chosen-id" });
+      const after = store.get().serverId;
+      expect(after).toBe(before);
+    });
+
+    it("accepts valid partial updates", async () => {
+      await store.update({ port: 8090, serverName: "Studio B" });
+      const current = store.get();
+      expect(current.port).toBe(8090);
+      expect(current.serverName).toBe("Studio B");
+    });
+  });
 });
 
 describe("getDefaults", () => {

--- a/server/src/config/settings-store.test.ts
+++ b/server/src/config/settings-store.test.ts
@@ -75,7 +75,7 @@ describe("createSettingsStore", () => {
 
       expect(settings.dmxDriver).toBe("enttec-usb-dmx-pro");
       expect(settings.port).toBe(9090);
-      expect(settings.host).toBe("0.0.0.0");
+      expect(settings.host).toBe("127.0.0.1");
       expect(settings.mdnsEnabled).toBe(true);
       expect(settings.setupCompleted).toBe(false);
       expect(settings.serverId).toMatch(/^[0-9a-f]{8}-/);
@@ -248,7 +248,7 @@ describe("getDefaults", () => {
     expect(defaults.dmxDriver).toBe("null");
     expect(defaults.dmxDevicePath).toBe("auto");
     expect(defaults.port).toBe(8080);
-    expect(defaults.host).toBe("0.0.0.0");
+    expect(defaults.host).toBe("127.0.0.1");
     expect(defaults.mdnsEnabled).toBe(true);
     expect(defaults.setupCompleted).toBe(false);
     expect(defaults.serverId).toBe("");

--- a/server/src/config/settings-store.ts
+++ b/server/src/config/settings-store.ts
@@ -40,6 +40,23 @@ export interface SettingsStore {
   readonly get: () => PersistedSettings;
 }
 
+// AUTH-C3: keys a client is allowed to patch. `serverId` is deliberately
+// omitted — it is auto-generated on first load and must not be
+// externally mutable.
+export const UPDATABLE_SETTINGS_KEYS: ReadonlySet<keyof PersistedSettings> =
+  new Set<keyof PersistedSettings>([
+    "dmxDriver",
+    "dmxDevicePath",
+    "port",
+    "udpPort",
+    "host",
+    "mdnsEnabled",
+    "setupCompleted",
+    "serverName",
+    "onboardingCompleted",
+    "driverOptions",
+  ]);
+
 function isValidSettings(data: unknown): data is Partial<PersistedSettings> {
   if (typeof data !== "object" || data === null || Array.isArray(data)) {
     return false;
@@ -95,7 +112,22 @@ export function createSettingsStore(filePath: string): SettingsStore {
     },
 
     async update(partial: Partial<PersistedSettings>): Promise<PersistedSettings> {
-      current = { ...current, ...partial };
+      // AUTH-C3: strip unknown keys and reject wrong-type values before
+      // merging. Only the allowlist keys are honored — serverId,
+      // __proto__, constructor, and any attacker-supplied key are dropped.
+      const filtered: Partial<PersistedSettings> = {};
+      if (partial && typeof partial === "object" && !Array.isArray(partial)) {
+        for (const key of UPDATABLE_SETTINGS_KEYS) {
+          if (Object.prototype.hasOwnProperty.call(partial, key)) {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (filtered as any)[key] = (partial as any)[key];
+          }
+        }
+      }
+      if (!isValidSettings(filtered)) {
+        throw new Error("Invalid settings update: type validation failed");
+      }
+      current = { ...current, ...filtered };
       await save(current);
       return { ...current };
     },

--- a/server/src/config/settings-store.ts
+++ b/server/src/config/settings-store.ts
@@ -26,7 +26,7 @@ const DEFAULTS: PersistedSettings = {
   dmxDevicePath: "auto",
   port: 8080,
   udpPort: 0,
-  host: "0.0.0.0",
+  host: "127.0.0.1",
   mdnsEnabled: true,
   setupCompleted: false,
   serverId: "",

--- a/server/src/dmx/dmx-dispatcher.test.ts
+++ b/server/src/dmx/dmx-dispatcher.test.ts
@@ -81,7 +81,7 @@ describe("DmxDispatcher (no coordinator)", () => {
 
     d.applyRawUpdate(undefined, { 1: 100 });
 
-    expect(mgr.applyRawUpdate).toHaveBeenCalledWith({ 1: 100 });
+    expect(mgr.applyRawUpdate).toHaveBeenCalledWith({ 1: 100 }, undefined);
   });
 
   it("delegates getChannelSnapshot to manager", () => {
@@ -157,7 +157,7 @@ describe("DmxDispatcher (no coordinator)", () => {
     // No coordinator present — should not throw
     d.applyRawUpdate(undefined, { 10: 200 });
 
-    expect(mgr.applyRawUpdate).toHaveBeenCalledWith({ 10: 200 });
+    expect(mgr.applyRawUpdate).toHaveBeenCalledWith({ 10: 200 }, undefined);
   });
 });
 
@@ -259,7 +259,7 @@ describe("DmxDispatcher (with coordinator)", () => {
 
     d.applyRawUpdate("uni-1", { 5: 200 });
 
-    expect(coord.applyRawUpdate).toHaveBeenCalledWith("uni-1", { 5: 200 });
+    expect(coord.applyRawUpdate).toHaveBeenCalledWith("uni-1", { 5: 200 }, undefined);
     expect(mgr.applyRawUpdate).not.toHaveBeenCalled();
   });
 

--- a/server/src/dmx/dmx-dispatcher.ts
+++ b/server/src/dmx/dmx-dispatcher.ts
@@ -10,7 +10,11 @@ import type { MultiUniverseCoordinator } from "./multi-universe-coordinator.js";
  */
 export interface DmxDispatcher {
   readonly applyFixtureUpdate: (universeId: string | undefined, payload: FixtureUpdatePayload) => number;
-  readonly applyRawUpdate: (universeId: string | undefined, channels: Record<number, number>) => DmxWriteResult;
+  readonly applyRawUpdate: (
+    universeId: string | undefined,
+    channels: Record<number, number>,
+    opts?: { bypassBlackout?: boolean },
+  ) => DmxWriteResult;
   readonly blackout: (universeId?: string) => DmxWriteResult;
   readonly whiteout: (universeId?: string) => DmxWriteResult;
   readonly resumeNormal: (universeId?: string) => DmxWriteResult;
@@ -34,11 +38,11 @@ export function createDmxDispatcher(
       return manager.applyFixtureUpdate(payload);
     },
 
-    applyRawUpdate(universeId, channels) {
+    applyRawUpdate(universeId, channels, opts) {
       if (coordinator && universeId) {
-        return coordinator.applyRawUpdate(universeId, channels);
+        return coordinator.applyRawUpdate(universeId, channels, opts);
       }
-      return manager.applyRawUpdate(channels);
+      return manager.applyRawUpdate(channels, opts);
     },
 
     blackout(universeId?) {

--- a/server/src/dmx/multi-universe-coordinator.test.ts
+++ b/server/src/dmx/multi-universe-coordinator.test.ts
@@ -209,7 +209,7 @@ describe("createMultiUniverseCoordinator", () => {
       const channels = { 1: 200, 2: 100 };
       coordinator.applyRawUpdate("uni-a", channels);
 
-      expect(managerA.applyRawUpdate).toHaveBeenCalledWith(channels);
+      expect(managerA.applyRawUpdate).toHaveBeenCalledWith(channels, undefined);
       expect(managerB.applyRawUpdate).not.toHaveBeenCalled();
       expect(defaultManager.applyRawUpdate).not.toHaveBeenCalled();
     });

--- a/server/src/dmx/multi-universe-coordinator.ts
+++ b/server/src/dmx/multi-universe-coordinator.ts
@@ -17,7 +17,7 @@ export interface MultiUniverseCoordinator {
   readonly registerSafePositions: (universeId: string, channels: Record<number, number>) => void;
   readonly lockChannels: (universeId: string, addresses: readonly number[]) => void;
   readonly unlockChannels: (universeId: string, addresses: readonly number[]) => void;
-  readonly applyRawUpdate: (universeId: string, channels: Record<number, number>) => DmxWriteResult;
+  readonly applyRawUpdate: (universeId: string, channels: Record<number, number>, opts?: { bypassBlackout?: boolean }) => DmxWriteResult;
   readonly getDmxSendStatus: (universeId: string) => DmxSendStatus | undefined;
   readonly getControlMode: (universeId: string) => ControlMode;
 }
@@ -96,8 +96,8 @@ export function createMultiUniverseCoordinator(
       resolve(universeId)?.unlockChannels(addresses);
     },
 
-    applyRawUpdate(universeId: string, channels: Record<number, number>): DmxWriteResult {
-      return resolve(universeId)?.applyRawUpdate(channels) ?? { ok: true };
+    applyRawUpdate(universeId: string, channels: Record<number, number>, opts?: { bypassBlackout?: boolean }): DmxWriteResult {
+      return resolve(universeId)?.applyRawUpdate(channels, opts) ?? { ok: true };
     },
 
     getDmxSendStatus(universeId: string): DmxSendStatus | undefined {

--- a/server/src/dmx/universe-manager.test.ts
+++ b/server/src/dmx/universe-manager.test.ts
@@ -186,14 +186,24 @@ describe("createUniverseManager", () => {
       expect(mock.updateAllCalls).toEqual([0]);
     });
 
-    it("allows applyRawUpdate during blackout", () => {
+    it("DMX-C2: applyRawUpdate honors blackout by default", () => {
       manager.blackout();
       mock.updateCalls.length = 0;
 
-      manager.applyRawUpdate({ 1: 255, 2: 128 });
+      const result = manager.applyRawUpdate({ 1: 255, 2: 128 });
+
+      // Should NOT write to hardware during blackout
+      expect(mock.updateCalls).toHaveLength(0);
+      expect(result.ok).toBe(true);
+    });
+
+    it("DMX-C2: applyRawUpdate allows bypass with bypassBlackout", () => {
+      manager.blackout();
+      mock.updateCalls.length = 0;
+
+      manager.applyRawUpdate({ 1: 255, 2: 128 }, { bypassBlackout: true });
 
       expect(mock.updateCalls).toHaveLength(1);
-      expect(mock.updateCalls[0]).toEqual({ 1: 255, 2: 128 });
     });
   });
 
@@ -542,6 +552,75 @@ describe("createUniverseManager", () => {
       manager.blackout();
       manager.whiteout();
       expect(manager.getControlMode()).toBe("whiteout");
+    });
+  });
+
+  describe("DMX-C2: applyRawUpdate validation + motor-guard", () => {
+    it("filters out invalid channel addresses (>512)", () => {
+      manager.applyRawUpdate({ 999: 128 });
+      // Invalid address should be stripped — either no write or 0 valid channels
+      if (mock.updateCalls.length > 0) {
+        expect(mock.updateCalls[0]).not.toHaveProperty("999");
+      }
+    });
+
+    it("filters out non-integer keys (fractional addresses)", () => {
+      manager.applyRawUpdate({ 1.5: 128 });
+      if (mock.updateCalls.length > 0) {
+        expect(mock.updateCalls[0]).not.toHaveProperty("1.5");
+      }
+    });
+
+    it("clamps values above 255", () => {
+      manager.applyRawUpdate({ 10: 300 });
+      expect(mock.updateCalls).toHaveLength(1);
+      expect(mock.updateCalls[0][10]).toBe(255);
+    });
+
+    it("clamps values below 0", () => {
+      manager.applyRawUpdate({ 10: -50 });
+      expect(mock.updateCalls).toHaveLength(1);
+      expect(mock.updateCalls[0][10]).toBe(0);
+    });
+
+    it("applies motor guard to addresses in safePositions", () => {
+      // Register address 10 as a motor channel (via safePositions)
+      manager.registerSafePositions({ 10: 128 });
+      mock.updateCalls.length = 0;
+
+      manager.applyRawUpdate({ 10: 255 });
+
+      expect(mock.updateCalls).toHaveLength(1);
+      // Motor guard should clamp 255 → 253 (buffer=4, max=253)
+      expect(mock.updateCalls[0][10]).toBe(253);
+    });
+
+    it("does not motor-clamp non-motor addresses", () => {
+      manager.registerSafePositions({ 10: 128 });
+      mock.updateCalls.length = 0;
+
+      // Address 5 is NOT in safePositions, so no motor clamp
+      manager.applyRawUpdate({ 5: 255 });
+
+      expect(mock.updateCalls).toHaveLength(1);
+      expect(mock.updateCalls[0][5]).toBe(255);
+    });
+
+    it("respects locked channels", () => {
+      manager.lockChannels([5]);
+
+      manager.applyRawUpdate({ 5: 255, 6: 128 });
+
+      expect(mock.updateCalls).toHaveLength(1);
+      // Channel 5 should be filtered out; only channel 6 written
+      expect(mock.updateCalls[0]).not.toHaveProperty("5");
+      expect(mock.updateCalls[0][6]).toBe(128);
+    });
+
+    it("returns ok with no write when all channels are invalid", () => {
+      const result = manager.applyRawUpdate({ 999: 128, 0: 64 });
+      expect(result.ok).toBe(true);
+      expect(mock.updateCalls).toHaveLength(0);
     });
   });
 });

--- a/server/src/dmx/universe-manager.ts
+++ b/server/src/dmx/universe-manager.ts
@@ -1,6 +1,7 @@
 import type { DmxUniverse } from "./driver-factory.js";
 import type { ChannelMap, FixtureUpdatePayload } from "../types/protocol.js";
 import { pipeLog, shouldSample } from "../logging/pipeline-logger.js";
+import { clampMotor } from "../fixtures/motor-guard.js";
 
 export type ControlMode = "normal" | "blackout" | "whiteout";
 
@@ -41,7 +42,10 @@ export interface UniverseManager {
   readonly getActiveChannelCount: () => number;
   readonly getChannelSnapshot: (start: number, count: number) => Record<number, number>;
   readonly getFullSnapshot: () => Record<number, number>;
-  readonly applyRawUpdate: (channels: Record<number, number>) => DmxWriteResult;
+  readonly applyRawUpdate: (
+    channels: Record<number, number>,
+    opts?: { bypassBlackout?: boolean },
+  ) => DmxWriteResult;
   readonly getDmxSendStatus: () => DmxSendStatus;
   /** Register safe center positions for motor channels (Pan/Tilt/etc).
    *  These are restored immediately after blackout/whiteout to prevent
@@ -321,8 +325,48 @@ export function createUniverseManager(
       return snapshot;
     },
 
-    applyRawUpdate(channels: Record<number, number>): DmxWriteResult {
-      for (const [ch, val] of Object.entries(channels)) {
+    applyRawUpdate(
+      channels: Record<number, number>,
+      opts: { bypassBlackout?: boolean } = {},
+    ): DmxWriteResult {
+      // DMX-C2: honor blackout state unless explicitly bypassed (e.g., bootstrap restore).
+      if (!opts.bypassBlackout && blackoutActive) {
+        pipeLog("debug", "applyRawUpdate BLOCKED (blackout active)");
+        return { ok: true };
+      }
+
+      // DMX-C2: validate + clamp through the same pipeline as applyFixtureUpdate.
+      // This closes the bypass that previously allowed out-of-range values,
+      // fractional addresses, and NaN keys to reach the serial bus.
+      const validated = buildDmxUpdate(channels);
+      if (validated === null) {
+        return { ok: true };
+      }
+
+      // DMX-C2: apply motor guard to addresses in safePositions. Motor
+      // channels (Pan, Tilt, Focus, Zoom, etc.) are clamped to 2-253 to
+      // prevent mechanical damage at end stops.
+      for (const key of Object.keys(validated)) {
+        const addr = Number(key);
+        if (safePositions.has(addr)) {
+          validated[addr] = clampMotor(validated[addr]);
+        }
+      }
+
+      // DMX-C2: respect locked channels (flash takes priority).
+      if (lockedChannels.size > 0) {
+        for (const key of Object.keys(validated)) {
+          if (lockedChannels.has(Number(key))) {
+            delete validated[Number(key)];
+          }
+        }
+        if (Object.keys(validated).length === 0) {
+          return { ok: true };
+        }
+      }
+
+      // Track active channels
+      for (const [ch, val] of Object.entries(validated)) {
         const chNum = Number(ch);
         if (val > 0) {
           activeChannels.set(chNum, val);
@@ -330,11 +374,12 @@ export function createUniverseManager(
           activeChannels.delete(chNum);
         }
       }
-      const count = Object.keys(channels).length;
-      const result = safeSend(`raw-update ${count}ch`, () => universe.update(channels));
+
+      const count = Object.keys(validated).length;
+      const result = safeSend(`raw-update ${count}ch`, () => universe.update(validated));
       if (shouldSample("rawUpdate")) {
-        const addrs = Object.keys(channels).map(Number).sort((a, b) => a - b);
-        const snapshot = addrs.map((a) => `${a}:${channels[Number(a)]}`).join(" ");
+        const addrs = Object.keys(validated).map(Number).sort((a, b) => a - b);
+        const snapshot = addrs.map((a) => `${a}:${validated[a]}`).join(" ");
         pipeLog("verbose", `RAW UPDATE: ${count}ch → ${snapshot}`);
       }
       return result;

--- a/server/src/middleware/api-key-auth.test.ts
+++ b/server/src/middleware/api-key-auth.test.ts
@@ -108,6 +108,154 @@ describe("API key authentication", () => {
       });
       expect(res.statusCode).toBe(401);
     });
+
+    // AUTH-C1: previously-unauthenticated mutating routes must require auth.
+    // Every one of these was bypassed under the prefix-allowlist fail-open logic.
+    describe("AUTH-C1 fail-closed: routes outside the old API_PREFIXES list", () => {
+      const unauthRequests: Array<{
+        name: string;
+        method: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
+        url: string;
+        payload?: unknown;
+      }> = [
+        { name: "GET /settings", method: "GET", url: "/settings" },
+        {
+          name: "PATCH /settings",
+          method: "PATCH",
+          url: "/settings",
+          payload: { port: 8081 },
+        },
+        {
+          name: "POST /settings/restart",
+          method: "POST",
+          url: "/settings/restart",
+        },
+        { name: "GET /universes", method: "GET", url: "/universes" },
+        {
+          name: "POST /universes",
+          method: "POST",
+          url: "/universes",
+          payload: { name: "x", driverType: "null" },
+        },
+        { name: "GET /groups", method: "GET", url: "/groups" },
+        {
+          name: "POST /groups",
+          method: "POST",
+          url: "/groups",
+          payload: { name: "g", fixtureIds: [] },
+        },
+        {
+          name: "POST /groups/:id/blackout",
+          method: "POST",
+          url: "/groups/abc/blackout",
+        },
+        {
+          name: "GET /user-fixtures",
+          method: "GET",
+          url: "/user-fixtures",
+        },
+        {
+          name: "POST /user-fixtures",
+          method: "POST",
+          url: "/user-fixtures",
+          payload: {},
+        },
+        {
+          name: "GET /remap-presets",
+          method: "GET",
+          url: "/remap-presets",
+        },
+        {
+          name: "PUT /remap-presets/:key",
+          method: "PUT",
+          url: "/remap-presets/test",
+          payload: { remap: {} },
+        },
+        {
+          name: "DELETE /remap-presets/:key",
+          method: "DELETE",
+          url: "/remap-presets/test",
+        },
+        { name: "GET /metrics", method: "GET", url: "/metrics" },
+        {
+          name: "GET /metrics/prometheus",
+          method: "GET",
+          url: "/metrics/prometheus",
+        },
+        { name: "GET /api/logs", method: "GET", url: "/api/logs" },
+        {
+          name: "POST /api/logs/clear",
+          method: "POST",
+          url: "/api/logs/clear",
+        },
+        {
+          name: "GET /api/logs/stream",
+          method: "GET",
+          url: "/api/logs/stream",
+        },
+        {
+          name: "GET /api/dmx/monitor",
+          method: "GET",
+          url: "/api/dmx/monitor",
+        },
+        {
+          name: "GET /api/dmx/snapshot",
+          method: "GET",
+          url: "/api/dmx/snapshot",
+        },
+        {
+          name: "GET /api/diagnostics/connection-log",
+          method: "GET",
+          url: "/api/diagnostics/connection-log",
+        },
+        {
+          name: "GET /config/export",
+          method: "GET",
+          url: "/config/export",
+        },
+        {
+          name: "POST /config/import",
+          method: "POST",
+          url: "/config/import",
+          payload: {},
+        },
+        {
+          name: "POST /api/settings/ofl-cache/clear",
+          method: "POST",
+          url: "/api/settings/ofl-cache/clear",
+        },
+      ];
+
+      for (const req of unauthRequests) {
+        it(`${req.name} returns 401 without key`, async () => {
+          const res = await app.inject({
+            method: req.method,
+            url: req.url,
+            payload: req.payload,
+          });
+          expect(res.statusCode).toBe(401);
+        });
+      }
+    });
+
+    describe("AUTH-C1 fail-closed: public routes remain accessible", () => {
+      it("GET /health stays public", async () => {
+        const res = await app.inject({ method: "GET", url: "/health" });
+        expect(res.statusCode).toBe(200);
+      });
+
+      it("GET /favicon.ico stays public", async () => {
+        const res = await app.inject({ method: "GET", url: "/favicon.ico" });
+        // 404 is acceptable if the asset isn't present in test; what matters
+        // is that we don't return 401.
+        expect(res.statusCode).not.toBe(401);
+      });
+
+      it("GET / (static root) stays public", async () => {
+        const res = await app.inject({ method: "GET", url: "/" });
+        expect(res.statusCode).not.toBe(401);
+      });
+    });
   });
 
   describe("when API_KEY is not set", () => {

--- a/server/src/middleware/api-key-auth.ts
+++ b/server/src/middleware/api-key-auth.ts
@@ -1,19 +1,35 @@
 import type { FastifyInstance } from "fastify";
 import { timingSafeEqual } from "node:crypto";
 
-const API_PREFIXES = [
-  "/fixtures",
-  "/update",
-  "/control",
-  "/ofl",
-  "/libraries",
-  "/search",
-  "/signalrgb",
-  "/debug",
+// AUTH-C1: Fail-closed auth. Everything requires `x-api-key` EXCEPT the
+// explicit public exemptions below. Previously this module used a prefix
+// allowlist and returned early on any URL not in the list, which meant
+// ~60% of state-mutating routes (settings, universes, groups, config,
+// metrics, logs, diagnostics, SSE streams) were unauthenticated.
+//
+// Public exemptions must be strictly enumerated and minimal:
+//   - `/health`           — operator liveness probe
+//   - `/favicon.ico`      — browser chrome; no security implications
+//   - `/` (static root)   — Alpine.js SPA entry (public by design; sensitive
+//                            actions require an API key from the same UI)
+//   - `/css/`, `/js/`,
+//     `/images/`          — static assets served by @fastify/static
+const PUBLIC_EXEMPT_PATHS: ReadonlySet<string> = new Set([
+  "/",
+  "/health",
+  "/favicon.ico",
+]);
+
+const PUBLIC_EXEMPT_PREFIXES: readonly string[] = [
+  "/css/",
+  "/js/",
+  "/images/",
 ];
 
-function isApiRoute(url: string): boolean {
-  return API_PREFIXES.some((prefix) => url.startsWith(prefix));
+export function isPublicRoute(url: string): boolean {
+  const path = url.split("?", 1)[0] ?? url;
+  if (PUBLIC_EXEMPT_PATHS.has(path)) return true;
+  return PUBLIC_EXEMPT_PREFIXES.some((prefix) => path.startsWith(prefix));
 }
 
 function keysMatch(provided: string, expected: string): boolean {
@@ -30,7 +46,7 @@ export function registerApiKeyAuth(
   apiKey: string,
 ): void {
   app.addHook("onRequest", async (request, reply) => {
-    if (request.url === "/health" || !isApiRoute(request.url)) {
+    if (isPublicRoute(request.url)) {
       return;
     }
 

--- a/server/src/routes/config.test.ts
+++ b/server/src/routes/config.test.ts
@@ -178,7 +178,7 @@ describe("config routes", () => {
           serverName: "Other Server",
           mdnsEnabled: false,
           port: 9999,
-          host: "127.0.0.1",
+          host: "192.168.1.100",
         },
       };
 
@@ -209,7 +209,7 @@ describe("config routes", () => {
 
       // Machine-specific settings should NOT be overwritten
       expect(settings.port).not.toBe(9999);
-      expect(settings.host).not.toBe("127.0.0.1");
+      expect(settings.host).not.toBe("192.168.1.100");
     });
 
     it("preserves per-fixture settings like overrides", async () => {

--- a/server/src/routes/control-modes.ts
+++ b/server/src/routes/control-modes.ts
@@ -51,7 +51,11 @@ export function registerControlModeRoutes(
     }
     for (const [uid, updates] of byUniverse) {
       totalChannelsSet += Object.keys(updates).length;
-      deps.dispatcher.applyRawUpdate(uid, updates);
+      // DMX-C2: the whiteout overlay runs after dispatcher.whiteout() which
+      // sets blackoutActive=true. The overlay is intentional — it corrects
+      // non-color channels (pan center, strobe open, dimmer full) that
+      // should not blindly be 255. Bypass the new blackout guard.
+      deps.dispatcher.applyRawUpdate(uid, updates, { bypassBlackout: true });
     }
 
     request.log.info(

--- a/server/src/routes/fixture-reset.ts
+++ b/server/src/routes/fixture-reset.ts
@@ -68,7 +68,7 @@ export function registerFixtureResetRoutes(
         activeTimers.delete(`reset:${fixture.id}`);
       }
 
-      deps.manager.applyRawUpdate({ [dmxAddr]: resetValue });
+      deps.manager.applyRawUpdate({ [dmxAddr]: resetValue }, { bypassBlackout: true });
 
       pipeLog("info",
         `RESET "${fixture.name}": DMX${dmxAddr} (${resetChannel.name}) → ${resetValue}, ` +
@@ -76,7 +76,7 @@ export function registerFixtureResetRoutes(
       );
 
       const timer = setTimeout(() => {
-        deps.manager.applyRawUpdate({ [dmxAddr]: 0 });
+        deps.manager.applyRawUpdate({ [dmxAddr]: 0 }, { bypassBlackout: true });
         activeTimers.delete(`reset:${fixture.id}`);
         pipeLog("info", `RESET "${fixture.name}": DMX${dmxAddr} restored to 0`);
       }, holdMs);

--- a/server/src/routes/fixture-test.ts
+++ b/server/src/routes/fixture-test.ts
@@ -94,9 +94,9 @@ export function registerFixtureTestRoutes(
       for (const addr of addresses) {
         zeros[addr] = 0;
       }
-      deps.manager.applyRawUpdate(zeros);
+      deps.manager.applyRawUpdate(zeros, { bypassBlackout: true });
     } else {
-      deps.manager.applyRawUpdate(snapshot);
+      deps.manager.applyRawUpdate(snapshot, { bypassBlackout: true });
     }
 
     holdSnapshots.delete(fixture.id);
@@ -133,7 +133,7 @@ export function registerFixtureTestRoutes(
       if (action === "flash") {
         const snapshot = deps.manager.getChannelSnapshot(start, count);
         const flashValues = buildFlashValues(fixture, snapshot, channelOffset);
-        const dmxResult = deps.manager.applyRawUpdate(flashValues);
+        const dmxResult = deps.manager.applyRawUpdate(flashValues, { bypassBlackout: true });
 
         request.log.info(
           {
@@ -167,7 +167,7 @@ export function registerFixtureTestRoutes(
 
         const flashValues = buildFlashValues(fixture, snapshot, channelOffset);
         const addresses = getFixtureAddresses(fixture);
-        const dmxResult = deps.manager.applyRawUpdate(flashValues);
+        const dmxResult = deps.manager.applyRawUpdate(flashValues, { bypassBlackout: true });
         deps.manager.lockChannels(addresses);
 
         request.log.info(
@@ -199,7 +199,7 @@ export function registerFixtureTestRoutes(
 
         const flashValues = buildFlashValues(fixture, snapshot, channelOffset);
         const addresses = getFixtureAddresses(fixture);
-        const dmxResult = deps.manager.applyRawUpdate(flashValues);
+        const dmxResult = deps.manager.applyRawUpdate(flashValues, { bypassBlackout: true });
         deps.manager.lockChannels(addresses);
 
         request.log.info(

--- a/server/src/routes/group-control.test.ts
+++ b/server/src/routes/group-control.test.ts
@@ -119,11 +119,13 @@ describe("Group control routes", () => {
       expect(dispatcher.applyRawUpdate).toHaveBeenCalledWith(
         "default",
         { 1: 0, 2: 0, 3: 0 },
+        { bypassBlackout: true },
       );
       // Second fixture: channels 10, 11, 12 zeroed
       expect(dispatcher.applyRawUpdate).toHaveBeenCalledWith(
         "default",
         { 10: 0, 11: 0, 12: 0 },
+        { bypassBlackout: true },
       );
 
       // Channels locked to prevent SignalRGB overwrite (per-fixture with universeId)
@@ -345,6 +347,7 @@ describe("Group control routes", () => {
       expect(dispatcher.applyRawUpdate).toHaveBeenCalledWith(
         "universe-2",
         expect.any(Object),
+        { bypassBlackout: true },
       );
 
       await uniApp.close();

--- a/server/src/routes/group-control.ts
+++ b/server/src/routes/group-control.ts
@@ -89,7 +89,7 @@ export function registerGroupControlRoutes(
       for (const fixture of fixtures) {
         const universeId = fixture.universeId ?? DEFAULT_UNIVERSE_ID;
         const zeros = buildZeroChannels(fixture);
-        lastDmxResult = deps.dispatcher.applyRawUpdate(universeId, zeros);
+        lastDmxResult = deps.dispatcher.applyRawUpdate(universeId, zeros, { bypassBlackout: true });
       }
 
       // Lock channels so incoming color frames don't overwrite
@@ -126,7 +126,7 @@ export function registerGroupControlRoutes(
       for (const fixture of fixtures) {
         const universeId = fixture.universeId ?? DEFAULT_UNIVERSE_ID;
         const channels = mapColor(fixture, 255, 255, 255, 1.0);
-        lastDmxResult = deps.dispatcher.applyRawUpdate(universeId, channels);
+        lastDmxResult = deps.dispatcher.applyRawUpdate(universeId, channels, { bypassBlackout: true });
       }
 
       // Lock channels so incoming color frames don't overwrite
@@ -170,7 +170,7 @@ export function registerGroupControlRoutes(
         snapshots.push({ universeId, channels: snapshot });
 
         const whiteChannels = mapColor(fixture, 255, 255, 255, 1.0);
-        lastDmxResult = deps.dispatcher.applyRawUpdate(universeId, whiteChannels);
+        lastDmxResult = deps.dispatcher.applyRawUpdate(universeId, whiteChannels, { bypassBlackout: true });
       }
 
       // Lock during flash so SignalRGB doesn't overwrite mid-flash
@@ -186,7 +186,7 @@ export function registerGroupControlRoutes(
       const timer = setTimeout(() => {
         unlockGroup(group.id);
         for (const { universeId, channels } of snapshots) {
-          deps.dispatcher.applyRawUpdate(universeId, channels);
+          deps.dispatcher.applyRawUpdate(universeId, channels, { bypassBlackout: true });
         }
         activeTimers.delete(group.id);
       }, durationMs);
@@ -225,7 +225,7 @@ export function registerGroupControlRoutes(
       for (const fixture of fixtures) {
         const universeId = fixture.universeId ?? DEFAULT_UNIVERSE_ID;
         const defaults = getFixtureDefaults(fixture);
-        lastDmxResult = deps.dispatcher.applyRawUpdate(universeId, defaults);
+        lastDmxResult = deps.dispatcher.applyRawUpdate(universeId, defaults, { bypassBlackout: true });
       }
 
       request.log.info(

--- a/server/src/routes/settings.test.ts
+++ b/server/src/routes/settings.test.ts
@@ -134,6 +134,50 @@ describe("settings routes", () => {
       expect(reloaded.serverName).toBe("Studio A");
     });
 
+    it("AUTH-C3: rejects unknown top-level keys", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/settings",
+        payload: { foo: "bar" },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("AUTH-C3: rejects wrong-type values", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/settings",
+        payload: { port: "evil" },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("AUTH-C3: rejects attempts to set serverId", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/settings",
+        payload: { serverId: "attacker-chosen" },
+      });
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("AUTH-C3: rejects __proto__ key", async () => {
+      const res = await app.inject({
+        method: "PATCH",
+        url: "/settings",
+        headers: { "content-type": "application/json" },
+        payload: '{"port": 8080, "__proto__": {"polluted": true}}',
+      });
+      // Either 400 from schema or 200 with the proto key stripped. Either
+      // way, global Object prototype must not be polluted.
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+      if (res.statusCode === 200) {
+        // If accepted, confirm the extra key didn't leak into settings.
+        const body = res.json();
+        expect(body.settings.port).toBe(8080);
+      }
+    });
+
     it("triggers mDNS republish when serverName changes", async () => {
       const republishMock = vi.fn();
       const mockAdvertiser = { unpublishAll: vi.fn(), republish: republishMock };

--- a/server/src/routes/settings.test.ts
+++ b/server/src/routes/settings.test.ts
@@ -174,7 +174,27 @@ describe("settings routes", () => {
   });
 
   describe("POST /settings/restart", () => {
-    it("returns restarting response and exits with non-zero code", async () => {
+    it("returns 400 when x-restart-confirm header is missing (AUTH-C2)", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/settings/restart",
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.json().error).toMatch(/confirm/i);
+    });
+
+    it("returns 400 when x-restart-confirm header has wrong value (AUTH-C2)", async () => {
+      const res = await app.inject({
+        method: "POST",
+        url: "/settings/restart",
+        headers: { "x-restart-confirm": "no" },
+      });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it("returns 200 and exits with non-zero code when confirmed", async () => {
       vi.useFakeTimers();
       const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
       const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
@@ -182,6 +202,7 @@ describe("settings routes", () => {
       const res = await app.inject({
         method: "POST",
         url: "/settings/restart",
+        headers: { "x-restart-confirm": "yes" },
       });
 
       expect(res.statusCode).toBe(200);

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -83,15 +83,38 @@ export function registerSettingsRoutes(
     },
   );
 
-  app.post("/settings/restart", async (_request, reply) => {
-    reply.send({ restarting: true });
+  app.post(
+    "/settings/restart",
+    {
+      // AUTH-C2: at most 2 restarts per hour to prevent remote reboot loops.
+      // The global rate limit (600/min) is far too permissive for an
+      // endpoint that terminates the process.
+      config: { rateLimit: { max: 2, timeWindow: "1 hour" } },
+    },
+    async (request, reply) => {
+      // AUTH-C2: require an explicit confirmation header so a CSRF-triggered
+      // fetch from a browser cannot restart the server. The header value is
+      // not a secret — it's a simple anti-CSRF deterrent paired with the
+      // fail-closed auth middleware.
+      const confirm = request.headers["x-restart-confirm"];
+      if (confirm !== "yes") {
+        return reply.status(400).send({
+          error:
+            "Restart requires the header `x-restart-confirm: yes` to confirm intent.",
+        });
+      }
 
-    setTimeout(() => {
-      // Exit with non-zero code so service managers (systemd Restart=on-failure,
-      // NSSM) will restart the process. Exit code 0 is treated as intentional
-      // shutdown and will NOT trigger a restart.
-      process.stderr.write("[DMXr] Restarting server (requested via settings UI)\n");
-      process.exit(1);
-    }, 500);
-  });
+      reply.send({ restarting: true });
+
+      setTimeout(() => {
+        // Exit with non-zero code so service managers (systemd Restart=on-failure,
+        // NSSM) will restart the process. Exit code 0 is treated as intentional
+        // shutdown and will NOT trigger a restart.
+        process.stderr.write(
+          "[DMXr] Restarting server (requested via settings UI)\n",
+        );
+        process.exit(1);
+      }, 500);
+    },
+  );
 }

--- a/server/src/routes/settings.ts
+++ b/server/src/routes/settings.ts
@@ -1,6 +1,9 @@
 import type { FastifyInstance } from "fastify";
 import type { SettingsStore } from "../config/settings-store.js";
-import type { PersistedSettings } from "../config/settings-store.js";
+import {
+  UPDATABLE_SETTINGS_KEYS,
+  type PersistedSettings,
+} from "../config/settings-store.js";
 import type { MdnsAdvertiser } from "../mdns/advertiser.js";
 import {
   listSerialPorts,
@@ -37,6 +40,7 @@ const RESTART_FIELDS: ReadonlySet<keyof PersistedSettings> = new Set([
   "host",
 ]);
 
+
 export function registerSettingsRoutes(
   app: FastifyInstance,
   deps: SettingsDeps,
@@ -55,23 +59,53 @@ export function registerSettingsRoutes(
     },
   );
 
-  app.patch("/settings", async (request, reply) => {
-    const body = request.body as Partial<PersistedSettings> | null;
-    if (!body || typeof body !== "object") {
-      return reply.status(400).send({ error: "Request body required" });
-    }
+  app.patch(
+    "/settings",
+    // AUTH-C3: intentionally NO Fastify schema here. Fastify's default
+    // Ajv config uses `removeAdditional: true`, which would silently strip
+    // unknown keys instead of returning 400. We want explicit rejection
+    // (clear feedback to callers, clear signal to attackers). Type
+    // validation is enforced inside `settingsStore.update()` via
+    // `isValidSettings`.
+    async (request, reply) => {
+      const rawBody = request.body as Record<string, unknown> | null;
+      if (!rawBody || typeof rawBody !== "object" || Array.isArray(rawBody)) {
+        return reply.status(400).send({ error: "Request body required" });
+      }
 
-    const settings = await deps.settingsStore.update(body);
-    const changedKeys = Object.keys(body) as (keyof PersistedSettings)[];
-    const requiresRestart = changedKeys.some((k) => RESTART_FIELDS.has(k));
+      // AUTH-C3: reject any key not in the allowlist (serverId,
+      // __proto__, constructor, attacker-supplied garbage). Use
+      // hasOwnProperty iteration to avoid prototype walk.
+      for (const key of Object.keys(rawBody)) {
+        if (!UPDATABLE_SETTINGS_KEYS.has(key as keyof PersistedSettings)) {
+          return reply.status(400).send({
+            error: `Unknown or read-only key: ${key}`,
+          });
+        }
+      }
 
-    if ("serverName" in body) {
-      deps.getMdnsAdvertiser?.()?.republish({ serverName: settings.serverName });
-    }
+      const body = rawBody as Partial<PersistedSettings>;
 
-    const response: PatchSettingsResponse = { settings, requiresRestart };
-    return response;
-  });
+      try {
+        const settings = await deps.settingsStore.update(body);
+        const changedKeys = Object.keys(body) as (keyof PersistedSettings)[];
+        const requiresRestart = changedKeys.some((k) => RESTART_FIELDS.has(k));
+
+        if ("serverName" in body) {
+          deps.getMdnsAdvertiser?.()?.republish({
+            serverName: settings.serverName,
+          });
+        }
+
+        const response: PatchSettingsResponse = { settings, requiresRestart };
+        return response;
+      } catch (err) {
+        return reply.status(400).send({
+          error: err instanceof Error ? err.message : "Invalid settings update",
+        });
+      }
+    },
+  );
 
   app.post(
     "/settings/scan-ports",

--- a/server/src/routes/universes.test.ts
+++ b/server/src/routes/universes.test.ts
@@ -106,6 +106,75 @@ describe("universe routes", () => {
       });
       expect(res.statusCode).toBe(409);
     });
+
+    describe("AUTH-C4 strict schema", () => {
+      it("rejects unknown keys", async () => {
+        const res = await app.inject({
+          method: "POST",
+          url: "/universes",
+          payload: {
+            name: "Good",
+            devicePath: "/dev/ttyUSB0",
+            driverType: "null",
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            extra: "evil" as any,
+          },
+        });
+        expect(res.statusCode).toBe(400);
+      });
+
+      it("rejects invalid driverType", async () => {
+        const res = await app.inject({
+          method: "POST",
+          url: "/universes",
+          payload: {
+            name: "Bad Driver",
+            devicePath: "/dev/ttyUSB0",
+            driverType: "bogus",
+          },
+        });
+        expect(res.statusCode).toBe(400);
+      });
+
+      it("rejects oversized name", async () => {
+        const res = await app.inject({
+          method: "POST",
+          url: "/universes",
+          payload: {
+            name: "x".repeat(1000),
+            devicePath: "/dev/ttyUSB0",
+            driverType: "null",
+          },
+        });
+        expect(res.statusCode).toBe(400);
+      });
+
+      it("rejects oversized devicePath", async () => {
+        const res = await app.inject({
+          method: "POST",
+          url: "/universes",
+          payload: {
+            name: "OK",
+            devicePath: "/dev/" + "x".repeat(1000),
+            driverType: "null",
+          },
+        });
+        expect(res.statusCode).toBe(400);
+      });
+
+      it("accepts a well-formed body", async () => {
+        const res = await app.inject({
+          method: "POST",
+          url: "/universes",
+          payload: {
+            name: "Valid",
+            devicePath: "/dev/ttyUSB0",
+            driverType: "enttec-usb-dmx-pro",
+          },
+        });
+        expect(res.statusCode).toBe(201);
+      });
+    });
   });
 
   describe("PATCH /universes/:id", () => {

--- a/server/src/routes/universes.ts
+++ b/server/src/routes/universes.ts
@@ -2,31 +2,53 @@ import type { FastifyInstance } from "fastify";
 import type { UniverseRegistry } from "../dmx/universe-registry.js";
 import type { FixtureStore } from "../fixtures/fixture-store.js";
 import type { DriverOptions } from "../types/protocol.js";
+import { VALID_DRIVERS } from "../config/server-config.js";
 
 interface UniverseRouteDeps {
   readonly registry: UniverseRegistry;
   readonly fixtureStore: FixtureStore;
 }
 
+// AUTH-C4: allowed top-level keys for POST /universes body. Used in both
+// the Fastify schema and the handler-level unknown-key check (Fastify's
+// default Ajv `removeAdditional: true` would silently strip extras; we
+// want explicit 400).
+const ALLOWED_CREATE_KEYS: ReadonlySet<string> = new Set([
+  "name",
+  "devicePath",
+  "driverType",
+  "serialNumber",
+  "driverOptions",
+]);
+
 const driverOptionsSchema = {
   type: "object" as const,
+  additionalProperties: false,
   properties: {
-    universe: { type: "number" as const },
-    port: { type: "number" as const },
-    sourceName: { type: "string" as const },
-    priority: { type: "number" as const },
+    universe: { type: "integer" as const, minimum: 0, maximum: 65535 },
+    port: { type: "integer" as const, minimum: 0, maximum: 65535 },
+    sourceName: { type: "string" as const, maxLength: 128 },
+    priority: { type: "integer" as const, minimum: 0, maximum: 200 },
   },
 };
 
+// AUTH-C4: strict schema with enum on driverType and bounded string lengths.
 const createSchema = {
   body: {
     type: "object" as const,
     required: ["name", "devicePath", "driverType"],
     properties: {
-      name: { type: "string" as const, minLength: 1 },
-      devicePath: { type: "string" as const, minLength: 1 },
-      driverType: { type: "string" as const, minLength: 1 },
-      serialNumber: { type: "string" as const },
+      name: { type: "string" as const, minLength: 1, maxLength: 128 },
+      devicePath: {
+        type: "string" as const,
+        minLength: 1,
+        maxLength: 256,
+      },
+      driverType: {
+        type: "string" as const,
+        enum: [...VALID_DRIVERS],
+      },
+      serialNumber: { type: "string" as const, maxLength: 128 },
       driverOptions: driverOptionsSchema,
     },
   },
@@ -36,10 +58,17 @@ const updateSchema = {
   body: {
     type: "object" as const,
     properties: {
-      name: { type: "string" as const, minLength: 1 },
-      devicePath: { type: "string" as const, minLength: 1 },
-      driverType: { type: "string" as const, minLength: 1 },
-      serialNumber: { type: "string" as const },
+      name: { type: "string" as const, minLength: 1, maxLength: 128 },
+      devicePath: {
+        type: "string" as const,
+        minLength: 1,
+        maxLength: 256,
+      },
+      driverType: {
+        type: "string" as const,
+        enum: [...VALID_DRIVERS],
+      },
+      serialNumber: { type: "string" as const, maxLength: 128 },
       driverOptions: driverOptionsSchema,
     },
   },
@@ -65,6 +94,20 @@ export function registerUniverseRoutes(
     "/universes",
     { schema: createSchema },
     async (req, reply) => {
+      // AUTH-C4: reject unknown top-level keys explicitly. Fastify's
+      // default Ajv `removeAdditional: true` would silently strip extras;
+      // we want a clear 400 for caller feedback.
+      const rawBody = req.body as Record<string, unknown> | null;
+      if (rawBody && typeof rawBody === "object") {
+        for (const key of Object.keys(rawBody)) {
+          if (!ALLOWED_CREATE_KEYS.has(key)) {
+            return reply.status(400).send({
+              error: `Unknown key: ${key}`,
+            });
+          }
+        }
+      }
+
       try {
         const universe = deps.registry.add(req.body);
         await deps.registry.save();

--- a/server/src/udp/udp-color-server.test.ts
+++ b/server/src/udp/udp-color-server.test.ts
@@ -199,3 +199,65 @@ describe("UdpColorServer", () => {
     await server.close(); // should not throw
   });
 });
+
+describe("UdpColorServer source filter (DMX-C1)", () => {
+  let store: FixtureStore;
+  let universe: ReturnType<typeof createMockUniverse>;
+  let filteredServer: UdpColorServer;
+
+  afterEach(async () => {
+    await filteredServer?.close();
+  });
+
+  it("drops packets from disallowed source IPs", async () => {
+    universe = createMockUniverse();
+    const manager = createUniverseManager(universe);
+    store = createTestFixtureStore();
+    addRgbFixture(store, "Fixture1", 1);
+
+    // Create server with allow list that excludes 127.0.0.1 (localhost)
+    filteredServer = createUdpColorServer({
+      fixtureStore: store,
+      manager,
+      allowedSources: ["10.0.0.0/8"], // only 10.x.x.x allowed
+    });
+    const port = await filteredServer.start(0);
+
+    // Send a valid color packet from localhost (127.0.0.1)
+    const packet = makePacket({
+      fixtures: [{ index: 0, r: 255, g: 128, b: 64, brightness: 255 }],
+    });
+    await sendUdpPacket(port, encodeColorPacket(packet));
+    await waitMs(50);
+
+    // Packet should be dropped — not processed, not counted as processed
+    const stats = filteredServer.getStats();
+    expect(stats.packetsReceived).toBe(1);
+    expect(stats.packetsProcessed).toBe(0);
+    expect(universe.updateCalls.length).toBe(0);
+  });
+
+  it("accepts packets from allowed source IPs (default RFC1918 + loopback)", async () => {
+    universe = createMockUniverse();
+    const manager = createUniverseManager(universe);
+    store = createTestFixtureStore();
+    addRgbFixture(store, "Fixture1", 1);
+
+    // Default allow list includes 127.0.0.0/8
+    filteredServer = createUdpColorServer({
+      fixtureStore: store,
+      manager,
+      allowedSources: ["127.0.0.0/8", "192.168.0.0/16"],
+    });
+    const port = await filteredServer.start(0);
+
+    const packet = makePacket({
+      fixtures: [{ index: 0, r: 255, g: 128, b: 64, brightness: 255 }],
+    });
+    await sendUdpPacket(port, encodeColorPacket(packet));
+    await waitMs(50);
+
+    expect(filteredServer.getStats().packetsProcessed).toBe(1);
+    expect(universe.updateCalls.length).toBeGreaterThan(0);
+  });
+});

--- a/server/src/udp/udp-color-server.ts
+++ b/server/src/udp/udp-color-server.ts
@@ -7,6 +7,16 @@ import type { MultiUniverseCoordinator } from "../dmx/multi-universe-coordinator
 import type { LatencyTracker } from "../metrics/latency-tracker.js";
 import type { MovementEngine } from "../fixtures/movement-interpolator.js";
 import { pipeLog, shouldSample } from "../logging/pipeline-logger.js";
+import { matchCidr } from "../utils/cidr.js";
+
+// DMX-C1: default allowed source CIDRs — loopback + RFC1918 private ranges.
+// Packets from any other source IP are silently dropped before parsing.
+export const DEFAULT_ALLOWED_SOURCES: readonly string[] = [
+  "127.0.0.0/8",
+  "10.0.0.0/8",
+  "172.16.0.0/12",
+  "192.168.0.0/16",
+];
 
 export interface UdpColorServerDeps {
   readonly fixtureStore: FixtureStore;
@@ -14,6 +24,7 @@ export interface UdpColorServerDeps {
   readonly coordinator?: MultiUniverseCoordinator;
   readonly latencyTracker?: LatencyTracker;
   readonly movementEngine?: MovementEngine;
+  readonly allowedSources?: readonly string[];
   readonly logger?: {
     readonly info: (msg: string) => void;
     readonly warn: (msg: string) => void;
@@ -37,6 +48,7 @@ export interface UdpColorServer {
 }
 
 export function createUdpColorServer(deps: UdpColorServerDeps): UdpColorServer {
+  const allowedSources = deps.allowedSources ?? DEFAULT_ALLOWED_SOURCES;
   let socket: Socket | null = null;
   let boundPort = 0;
   let packetsReceived = 0;
@@ -58,6 +70,17 @@ export function createUdpColorServer(deps: UdpColorServerDeps): UdpColorServer {
 
         sock.on("message", (msg, rinfo) => {
           packetsReceived++;
+
+          // DMX-C1: drop packets from disallowed source IPs before parsing.
+          // This is the primary defense against unauthenticated UDP injection
+          // from untrusted LAN peers when the server is bound to 0.0.0.0.
+          if (allowedSources.length > 0 && !matchCidr(rinfo.address, allowedSources)) {
+            if (shouldSample("udp:source-denied")) {
+              pipeLog("warn", `UDP packet dropped from disallowed source ${rinfo.address}:${rinfo.port}`);
+            }
+            return;
+          }
+
           const receiveTime = performance.now();
 
           const packet = parseColorPacket(msg);

--- a/server/src/utils/cidr.test.ts
+++ b/server/src/utils/cidr.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { matchCidr } from "./cidr.js";
+
+describe("matchCidr", () => {
+  it("matches loopback /8", () => {
+    expect(matchCidr("127.0.0.1", ["127.0.0.0/8"])).toBe(true);
+    expect(matchCidr("127.255.255.255", ["127.0.0.0/8"])).toBe(true);
+  });
+
+  it("matches Class C /16", () => {
+    expect(matchCidr("192.168.1.5", ["192.168.0.0/16"])).toBe(true);
+    expect(matchCidr("192.168.255.255", ["192.168.0.0/16"])).toBe(true);
+  });
+
+  it("rejects public IP against RFC1918 list", () => {
+    expect(
+      matchCidr("1.2.3.4", [
+        "127.0.0.0/8",
+        "10.0.0.0/8",
+        "172.16.0.0/12",
+        "192.168.0.0/16",
+      ]),
+    ).toBe(false);
+  });
+
+  it("matches 10.x.x.x /8", () => {
+    expect(matchCidr("10.0.0.1", ["10.0.0.0/8"])).toBe(true);
+    expect(matchCidr("10.255.255.254", ["10.0.0.0/8"])).toBe(true);
+  });
+
+  it("matches 172.16-31.x.x /12", () => {
+    expect(matchCidr("172.16.0.1", ["172.16.0.0/12"])).toBe(true);
+    expect(matchCidr("172.31.255.255", ["172.16.0.0/12"])).toBe(true);
+    expect(matchCidr("172.32.0.1", ["172.16.0.0/12"])).toBe(false);
+  });
+
+  it("matches exact host /32", () => {
+    expect(matchCidr("1.2.3.4", ["1.2.3.4/32"])).toBe(true);
+    expect(matchCidr("1.2.3.5", ["1.2.3.4/32"])).toBe(false);
+  });
+
+  it("matches /0 (everything)", () => {
+    expect(matchCidr("8.8.8.8", ["0.0.0.0/0"])).toBe(true);
+  });
+
+  it("returns false for empty allow list", () => {
+    expect(matchCidr("192.168.1.1", [])).toBe(false);
+  });
+
+  it("handles malformed CIDR gracefully (returns false)", () => {
+    expect(matchCidr("192.168.1.1", ["garbage"])).toBe(false);
+    expect(matchCidr("192.168.1.1", ["not/a/cidr"])).toBe(false);
+  });
+
+  it("handles IPv6 addresses (returns false — not supported)", () => {
+    expect(matchCidr("::1", ["127.0.0.0/8"])).toBe(false);
+  });
+});

--- a/server/src/utils/cidr.ts
+++ b/server/src/utils/cidr.ts
@@ -1,0 +1,49 @@
+/**
+ * DMX-C1: lightweight IPv4-only CIDR matcher for the UDP source allow-list.
+ * No external dependencies. IPv6 addresses return false (deny by default).
+ */
+
+function ipToUint32(ip: string): number | null {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return null;
+  let result = 0;
+  for (const part of parts) {
+    const n = Number(part);
+    if (!Number.isInteger(n) || n < 0 || n > 255) return null;
+    result = (result << 8) | n;
+  }
+  // Ensure unsigned 32-bit
+  return result >>> 0;
+}
+
+function parseCidr(cidr: string): { network: number; mask: number } | null {
+  const [networkStr, bitsStr] = cidr.split("/");
+  if (!networkStr || !bitsStr) return null;
+
+  const bits = Number(bitsStr);
+  if (!Number.isInteger(bits) || bits < 0 || bits > 32) return null;
+
+  const network = ipToUint32(networkStr);
+  if (network === null) return null;
+
+  // Shift left then unsigned-right-shift to get a 32-bit mask
+  const mask = bits === 0 ? 0 : (~0 << (32 - bits)) >>> 0;
+  return { network: (network & mask) >>> 0, mask };
+}
+
+/**
+ * Returns true if `ip` falls within any of the CIDR ranges in `allowList`.
+ * IPv6 addresses and malformed CIDRs are silently rejected (return false).
+ */
+export function matchCidr(ip: string, allowList: readonly string[]): boolean {
+  const addr = ipToUint32(ip);
+  if (addr === null) return false;
+
+  for (const cidr of allowList) {
+    const parsed = parseCidr(cidr);
+    if (!parsed) continue;
+    if ((addr & parsed.mask) >>> 0 === parsed.network) return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary
Closes 8 of 12 CRITICAL findings from the security audit (`docs/SECURITY-AUDIT-2026-04-08.md`). Remaining 3 (DMX-C3 StrobeGuard, DMX-C4/C5/C6 physical-safety) deferred to Phase 2.

### Auth layer (4 CRITICALs closed)
- **AUTH-C1** — Inverted `api-key-auth.ts` from prefix allowlist (fail-open) to explicit public exemption list (fail-closed). 24 previously-unauthenticated mutating routes now require `x-api-key`.
- **AUTH-C2** — `POST /settings/restart` now requires `x-restart-confirm: yes` header + rate-limited to 2/hour.
- **AUTH-C3** — `PATCH /settings` strict key allowlist via `UPDATABLE_SETTINGS_KEYS`. `serverId` is now read-only. Unknown keys return 400.
- **AUTH-C4** — `POST /universes` strict schema: `driverType` constrained to `VALID_DRIVERS` enum, bounded string lengths, unknown-key rejection.

### DMX layer (2 CRITICALs closed)
- **DMX-C1** — Default host changed to `127.0.0.1` (was `0.0.0.0`). New CIDR allow-list on UDP color server drops packets from non-RFC1918 sources.
- **DMX-C2** — `applyRawUpdate` now routes through `buildDmxUpdate` (validates 1-512, integer keys, clamps 0-255), applies motor-guard on safePosition addresses, honors blackout state, and respects locked channels. `{ bypassBlackout: true }` opt-in for intentional control-mode callers.

### Supply chain (2 CRITICALs closed)
- **SUPPLY-C1** — All 13 GitHub Action references pinned to immutable 40-char commit SHAs.
- **SUPPLY-C2** — Node.js downloads verified against official SHASUMS256.txt; NSSM verified against hard-pinned SHA-256.

### Bonus
- `npm audit fix` for newly-published basic-ftp advisory (GHSA-6v7q-wjvx-w8wg).

## Test plan
- [x] `npm test` → 1675 passed (+63 new security tests), 11 skipped
- [x] `npx tsc --noEmit` → clean
- [x] `npm audit --audit-level=high` → 0 vulnerabilities
- [x] Remote CI (typecheck, test, audit) → all green
- [ ] Live smoke test on VM kiosk (post-merge)
- [ ] Manual build-server.yml trigger to verify checksum steps (post-merge)

## Methodology
Strict red-green-refactor TDD per finding. Every security invariant encoded as a failing test before production fix. 9 commits, each closing one or two CRITICALs.