### PR TITLE
chore(deps): consolidated dep bumps + fast-uri security fix (CVE-2026-6321, CVE-2026-6322)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,12 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: github/codeql-action/init@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
+      - uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v3
         with:
           languages: ${{ matrix.language }}
 
-      - uses: github/codeql-action/autobuild@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
+      - uses: github/codeql-action/autobuild@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v3
 
-      - uses: github/codeql-action/analyze@0daab03d71ff584ef619d027a3fd9146679c5d84 # v3
+      - uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v4
         with:
           fail-on-severity: high

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1595,9 +1595,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -2903,9 +2903,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- `github/codeql-action` v3: `0daab03` → `68bde55` (3.35.3 → 3.35.4) — closes PR #105
- `actions/dependency-review-action` v4: `2031cfc` → `a1d282b` (4.9.0 → 5.0.0) — closes PR #106
- `@types/node`: 25.6.0 → 25.6.2 — closes PR #107
- **`fast-uri`: 3.1.0 → 3.1.2** — addresses CVE-2026-6321 (path traversal, CVSS 7.5) and CVE-2026-6322 (host confusion, CVSS 7.5) via transitive update through `fastify → @fastify/ajv-compiler` and `fastify → fast-json-stringify`

## Test plan

- [x] `npm test` — 1641 passing, 0 failures
- [x] `npx tsc --noEmit` — clean
- [x] `npm audit` — 0 vulnerabilities after update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pinned commit references for GitHub Actions workflows related to CodeQL analysis and dependency review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->