### PR TITLE
docs: streamline CLAUDE.md to defer to global rules

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+<!-- Title: Conventional Commits -->
+## Why
+## What
+## Testing
+- [ ] `cd server && npm test` passes (vitest)
+- [ ] `cd server && npx tsc --noEmit` clean (strict typecheck)
+- [ ] Manual verification: <steps>
+- [ ] CI green
+🤖 Co-authored by Claude. Closes #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # DMXr for SignalRGB
 
+> Follows the global `~/.claude/rules` (code · workflow · security · agents). This file holds only DMXr-specific facts and overrides.
+
 DMXr bridges DMX lighting fixtures into SignalRGB as first-class canvas devices. Two-component architecture: a SignalRGB JS plugin and a Node.js server using Fastify + dmx-ts for ENTTEC DMX USB Pro output.
 
 ## Repo Structure
@@ -66,9 +68,9 @@ Browser (http://localhost:8080)       SignalRGB Plugin (DMXr.js)
 
 ```bash
 cd server
-npm test          # vitest (tests co-located: *.test.ts next to source)
-npx tsc --noEmit  # type check (strict mode)
-npm run build     # compile to dist/
+npm test          # vitest run (tests co-located: *.test.ts next to source)
+npx tsc --noEmit  # type check (strict mode) -- the clean-check; no separate ESLint
+npm run build     # tsc -> dist/
 ```
 
 ## Key Conventions
@@ -96,21 +98,15 @@ npm run build     # compile to dist/
 - `DMXr.qml` for settings panel UI
 - Uses `device.color(x,y)` to sample canvas (not `getColors("Inline")` which is broken)
 
+## Testing (DMXr-specific)
+
+- **Coverage is DIAGNOSTIC** -- vitest with no enforced minimum.
+- Favor tests at **module/API boundaries** over internals; mock only at process edges (stores/dispatcher injected as deps).
+- **Pin every bug-fix with a regression test referencing the commit SHA.**
+
 ## Note
 
 For deployment credentials, SSH access, and machine-specific details -- query local `.claude/` memory files (not committed to repo). These vary per developer machine.
-
-## Testing philosophy
-
-Every test must justify itself against four properties:
-1. Protects against real regressions (user-visible behavior)
-2. Resists refactoring (doesn't break on internal restructuring)
-3. Fast enough to actually run
-4. Readable and maintainable
-
-Coverage % is a diagnostic, not a target. Tests at module/API boundaries
-beat tests on internals. Mocks belong at process edges, not everywhere.
-Pin every bug-fix with a regression test referencing the commit SHA.
 
 ## Maintenance
 


### PR DESCRIPTION
## Why

`~/.claude/rules/` was consolidated into themed files (code · workflow · security · agents) that auto-load every session for all projects. A repo `CLAUDE.md` should hold only project-specific facts and overrides, never restate the global rules. This normalizes DMXr's CLAUDE.md to that convention as part of a fleet-wide unification.

## What

- Added a deferral header pointing at the global `~/.claude/rules`.
- Removed the generic four-property "Testing philosophy" prose now fully covered by the global rules.
- Preserved all DMXr-specific substance: immutable stores + `saveChain` promise serialization, atomic file writes, `DmxWriteResult` propagation, TypeScript strict mode, co-located `*.test.ts` files, dependency-injected mock patterns (stores/dispatcher), module/API-boundary testing focus, **coverage is diagnostic (vitest, no enforced minimum)**, SHA-pinned bug-fix regression tests, and the build/test/typecheck commands.
- Added `.github/PULL_REQUEST_TEMPLATE.md` with a Testing checklist tailored to the vitest + `tsc --noEmit` stack.
- Net: CLAUDE.md 121 -> 117 lines.

## Testing

- [ ] `cd server && npm test` passes (vitest) -- unaffected, docs-only change
- [ ] `cd server && npx tsc --noEmit` clean -- unaffected, docs-only change
- [ ] Manual verification: header renders, no global-rule content remains, PR template appears on new PRs
- [ ] CI green

🤖 Co-authored by Claude. Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated pull request template with enhanced structure including new sections for testing requirements, strict type-checking validation, and continuous integration confirmation.
  * Refined development and testing documentation with clarified guidance on test execution procedures and coverage standards.

* **Chores**
  * Improved internal process workflows and documentation organization to support better development practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->