### PR TITLE
chore(ci): run Dependabot alongside Renovate, repin dependency-review-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+# Dependabot runs alongside Mend Renovate (renovate.json) on purpose.
+#
+# Every Renovate run in this org was suppressed by Mend's platform-level
+# `mode=silent`, which blocked all PRs and Dependency Dashboards. Dependabot is
+# enabled here so dependency updates stay visible, and so the two tools can be
+# compared side by side before we settle on one. Expect duplicate PRs until then
+# -- that is intentional, not a misconfiguration.
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/server"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 20
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      npm-server-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 20
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      github-actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v4
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: high

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,7 +12,7 @@
         "@fastify/cors": "^11.2.0",
         "@fastify/helmet": "^13.0.2",
         "@fastify/rate-limit": "^10.3.0",
-        "@fastify/static": "^9.1.3",
+        "@fastify/static": "^10.1.2",
         "better-sqlite3": "^12.10.0",
         "bonjour-service": "^1.3.0",
         "dmx-ts": "0.4.0",
@@ -827,9 +827,9 @@
       }
     },
     "node_modules/@fastify/static": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-9.1.3.tgz",
-      "integrity": "sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==",
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/@fastify/static/-/static-10.1.2.tgz",
+      "integrity": "sha512-G/g18cG9tLutT/OVyN1AIsHIl9L1UwmJ+S3dkyhVpplIx0nEMicd7RGQ+uJLyhKKF4a3tTcQydccn3Mop1fX+Q==",
       "funding": [
         {
           "type": "github",
@@ -843,12 +843,29 @@
       "license": "MIT",
       "dependencies": {
         "@fastify/accept-negotiator": "^2.0.0",
+        "@fastify/error": "^4.0.0",
         "@fastify/send": "^4.0.0",
-        "content-disposition": "^1.0.1",
-        "fastify-plugin": "^5.0.0",
+        "content-disposition": "^2.0.1",
+        "fastify-plugin": "^6.0.0",
         "fastq": "^1.17.1",
         "glob": "^13.0.0"
       }
+    },
+    "node_modules/@fastify/static/node_modules/fastify-plugin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-6.0.0.tgz",
+      "integrity": "sha512-fZOty7z3O7vOliF6d8bHE3wiEh1KcNnKEQensSgTk9C1DvN6nRLS++XVd86v33Hw/8u9Un8A1zDrQ8ujcQDHEg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
@@ -2191,15 +2208,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer": {
@@ -2348,9 +2365,9 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-2.0.1.tgz",
+      "integrity": "sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2900,9 +2917,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -3014,9 +3031,9 @@
       "license": "MIT"
     },
     "node_modules/find-my-way": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.5.0.tgz",
-      "integrity": "sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
+      "integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3336,9 +3353,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -3881,9 +3898,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4223,9 +4240,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -4243,7 +4260,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/server/package.json
+++ b/server/package.json
@@ -21,7 +21,7 @@
     "@fastify/cors": "^11.2.0",
     "@fastify/helmet": "^13.0.2",
     "@fastify/rate-limit": "^10.3.0",
-    "@fastify/static": "^9.1.3",
+    "@fastify/static": "^10.1.2",
     "better-sqlite3": "^12.10.0",
     "bonjour-service": "^1.3.0",
     "dmx-ts": "0.4.0",


### PR DESCRIPTION
This was written agentically; verify its assertions and edit accordingly:

## Why

Renovate has been this repo's only dependency-update tool, and **every run was
suppressed by Mend's platform-level `mode=silent`** — no PRs, no Dependency
Dashboard. That has now been switched off org-wide. Meanwhile this repo carries
**10 open Dependabot vulnerability alerts, 8 of them high severity**, and had
Dependabot security updates switched off.

This repo also showed a **Warning** in the Mend portal, diagnosed below.

## What

**1. Dependabot config.** Adds `.github/dependabot.yml` covering the `/server` npm
workspace and the workflow action pins, with group shapes and Conventional Commit
prefixes mirroring `renovate.json` so both tools' output is directly comparable.

**2. Fixes the Mend lookup warning.** Renovate reported:

> Could not determine new digest for update (github-tags package
> `actions/dependency-review-action`) — `.github/workflows/dependency-review.yml`

Root cause: the pin's trailing comment read `# v4`, but upstream **no longer
publishes a floating `v4` tag** — it ships `v4.9.0`, `v5.0.0`, etc. The commit SHA
was valid, so the workflow kept running fine; but Renovate resolves updates from the
comment, and the tag it names does not exist. Repinned to `v4.9.0` and its real SHA
(`2031cfc`). `v5.0.0` is deliberately left for a reviewed major bump, since
`fail-on-severity` behavior may differ across majors.

Dependabot alerts and security updates were also enabled on the repo.

**Running both tools at once is deliberate and temporary** — it restores coverage now
and gives a side-by-side before we pick one. Expect duplicate PRs until then.

**3. Clears the six high-severity advisories blocking CI.** The `audit` job was already
red on `main` — the exact drift this PR's Dependabot config exists to prevent. Five
advisories (`brace-expansion`, `fast-uri`, `find-my-way`, `js-yaml`, `postcss`) resolve
within existing ranges via the lockfile alone. `@fastify/static` needed a **9 → 10 major
bump** to close [GHSA-8pvw-jcv7-9cmj](https://github.com/advisories/GHSA-8pvw-jcv7-9cmj)
(authorization bypass via non-canonical URL paths) and
[GHSA-83w8-p2f5-377r](https://github.com/advisories/GHSA-83w8-p2f5-377r) (route guard
bypass via path traversal). That plugin serves the live web UI, so both are reachable
rather than theoretical. Registration uses only `root`/`prefix`/`decorateReply`, none of
which changed in v10.

## Testing

- [ ] Dependabot parses the config without errors (Insights → Dependency graph → Dependabot)
- [x] `dependency-review.yml` still runs green on this PR with the new pin
- [ ] Mend's next job log for this repo shows no dependency-lookup warning
- [ ] Security-update PRs open against the existing 10 alerts
- [x] `npm audit --audit-level=high` reports 0 vulnerabilities (was 6 high)
- [x] `tsc --noEmit` clean; 1641 tests pass, 11 skipped
- [x] Server boots under `@fastify/static` v10 — `/` and `/js/app.js` return 200, path traversal returns 404
- [x] CI green (7/7 checks)

🤖 Co-authored by Claude Opus 5 (1M context).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly dependency update checks for server packages and GitHub Actions.
  * Grouped compatible minor and patch updates to simplify maintenance.
  * Updated dependency review checks to the latest pinned version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
